### PR TITLE
Add ingress UI for managing Squid proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
+FROM ${BUILD_FROM}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV LANG C.UTF-8
+
+RUN apk add --no-cache squid apache2-utils python3 py3-pip openssl ca-certificates jq
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY app /app
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+EXPOSE 3128
+
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# HA_SQUID_PROXY
+# Home Assistant Squid Proxy Add-on
+
+This add-on packages the Squid proxy daemon with a lightweight FastAPI-based management service and Ingress UI to provide configuration, lifecycle control, authentication management, certificate handling, and log visibility for HTTPS interception.
+
+## Features
+- Generates `squid.conf` from Home Assistant options stored in `/data/options.json`.
+- Optional HTTP basic authentication backed by htpasswd stored at `/data/users.htpasswd`.
+- Optional SSL bump support using a generated CA stored under `/ssl`.
+- Lifecycle endpoints and UI controls to start, stop, restart, and reload Squid.
+- Ingress UI for option management, SSL bump controls, user management, and live log tail for `access.log` and `cache.log` stored under `/data/logs`.
+
+## File locations
+- Squid configuration: `/data/squid.conf`
+- Credentials: `/data/users.htpasswd`
+- Logs: `/data/logs/access.log`, `/data/logs/cache.log`
+- Cache storage: `/data/cache`
+- Certificates: `/ssl/squid_ca.pem`, `/ssl/squid_ca.key`
+
+## Development
+1. Build the image:
+   ```bash
+   docker build -t ha-squid-proxy .
+   ```
+2. Run the container (requires host network privileges for Squid):
+   ```bash
+   docker run --rm -it -p 3128:3128 -p 8099:8099 -v $(pwd)/data:/data -v $(pwd)/ssl:/ssl --cap-add=NET_ADMIN ha-squid-proxy
+   ```
+3. The management API and UI are exposed on port `8099` and implement endpoints under `/` (see `app/main.py`). In Home Assistant the UI is available via Ingress.
+
+## Ingress UI
+- **Status & lifecycle:** Start, stop, restart, reload, and view PID/uptime/port/auth/SSL-bump state.
+- **Options editor:** Update port, allowed CIDRs, auth toggle, SSL bump toggle, cache size, and CA auto-generation with validation to prevent empty networks.
+- **Certificate management:** Generate/regenerate CA for SSL bumping and download the certificate.
+- **User management:** Add/update/delete htpasswd users when authentication is enabled.
+- **Logs:** Tail the latest entries of `access.log` and `cache.log` with refresh controls.
+
+## Configuration options
+The add-on uses Home Assistant options defined in `config.yaml`:
+- `proxy_port`: Squid listening port (default `3128`).
+- `allowed_networks`: CIDR list of clients permitted to connect.
+- `enable_auth`: Toggle HTTP basic authentication (no default users created).
+- `enable_ssl_bump`: Enable HTTPS interception; requires a CA certificate/key.
+- `cache_size_mb`: Disk cache size in MB (default `512`).
+- `generate_ca_on_first_run`: If true and SSL bump is enabled, the add-on will auto-generate a CA.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,439 @@
+import asyncio
+import ipaddress
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader
+from pydantic import BaseModel, Field, ValidationError
+
+DATA_DIR = Path("/data")
+LOG_DIR = DATA_DIR / "logs"
+CACHE_DIR = DATA_DIR / "cache"
+SSL_DIR = Path("/ssl")
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+CONFIG_PATH = DATA_DIR / "squid.conf"
+HTPASSWD_PATH = DATA_DIR / "users.htpasswd"
+PID_FILE = Path("/run/squid.pid")
+CA_CERT = SSL_DIR / "squid_ca.pem"
+CA_KEY = SSL_DIR / "squid_ca.key"
+OPTIONS_PATH = DATA_DIR / "options.json"
+
+env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
+app = FastAPI(title="Squid Proxy Manager")
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+app.mount("/static", StaticFiles(directory=str(TEMPLATE_DIR.parent / "static")), name="static")
+
+
+def read_options() -> dict:
+    if OPTIONS_PATH.exists():
+        with OPTIONS_PATH.open() as f:
+            return json.load(f)
+    return {}
+
+
+class Options(BaseModel):
+    proxy_port: int = Field(default=3128, ge=1, le=65535)
+    allowed_networks: List[str] = Field(default_factory=lambda: ["127.0.0.1/32"])
+    enable_auth: bool = False
+    enable_ssl_bump: bool = False
+    cache_size_mb: int = Field(default=512, ge=16, le=10240)
+    generate_ca_on_first_run: bool = False
+
+    @classmethod
+    def model_validate(cls, value, *args, **kwargs):  # type: ignore[override]
+        opts = super().model_validate(value, *args, **kwargs)
+        if not opts.allowed_networks:
+            raise ValueError("At least one allowed network must be provided")
+        for cidr in opts.allowed_networks:
+            try:
+                ipaddress.ip_network(cidr, strict=False)
+            except ValueError as exc:
+                raise ValueError(f"Invalid allowed network {cidr}: {exc}") from exc
+        return opts
+
+    @classmethod
+    def from_file(cls) -> "Options":
+        raw = read_options()
+        try:
+            opts = cls(**raw)
+        except ValidationError as err:
+            raise RuntimeError(f"Invalid options: {err}") from err
+        return opts
+
+
+@dataclass
+class ServiceStatus:
+    running: bool
+    pid: Optional[int]
+    uptime: Optional[str]
+    proxy_port: int
+    ssl_bump: bool
+    user_count: int
+
+
+class UserModel(BaseModel):
+    username: str
+    password: str
+
+
+class LogQuery(BaseModel):
+    file: str = Field(pattern="^(access|cache)\.log$")
+    lines: int = Field(default=50, ge=1, le=500)
+
+
+class UserDeleteRequest(BaseModel):
+    username: str
+
+
+async def ensure_directories() -> None:
+    for path in (DATA_DIR, LOG_DIR, CACHE_DIR, SSL_DIR):
+        path.mkdir(parents=True, exist_ok=True)
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def render_config(options: Options) -> str:
+    template = env.get_template("squid.conf.j2")
+    rendered = template.render(
+        options=options,
+        pid_file=str(PID_FILE),
+        config_path=str(CONFIG_PATH),
+        log_dir=str(LOG_DIR),
+        cache_dir=str(CACHE_DIR),
+        htpasswd=str(HTPASSWD_PATH),
+        ca_cert=str(CA_CERT),
+        ca_key=str(CA_KEY),
+    )
+    return rendered
+
+
+def write_config(options: Options) -> None:
+    CONFIG_PATH.write_text(render_config(options))
+
+
+def init_cache(options: Options) -> None:
+    if not (CACHE_DIR / "00").exists():
+        subprocess.run([
+            "squid",
+            "-z",
+            "-f",
+            str(CONFIG_PATH),
+        ], check=True)
+
+
+def start_squid(options: Options) -> None:
+    write_config(options)
+    init_cache(options)
+    subprocess.run([
+        "squid",
+        "-f",
+        str(CONFIG_PATH),
+        "-s",
+        "-N",
+        "-Y",
+        "-C",
+        "-d",
+        "1",
+    ], check=True)
+
+
+def stop_squid() -> None:
+    subprocess.run(["squid", "-k", "shutdown", "-f", str(CONFIG_PATH)], check=False)
+
+
+def reload_squid(options: Options) -> None:
+    write_config(options)
+    subprocess.run(["squid", "-k", "reconfigure", "-f", str(CONFIG_PATH)], check=True)
+
+
+def read_pid() -> Optional[int]:
+    try:
+        return int(PID_FILE.read_text().strip())
+    except Exception:
+        return None
+
+
+def service_status(options: Options) -> ServiceStatus:
+    pid = read_pid()
+    running = False
+    uptime: Optional[str] = None
+    if pid:
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text().split()
+            start_ticks = int(stat[21])
+            ticks = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+            with Path("/proc/uptime").open() as f:
+                uptime_seconds = float(f.read().split()[0])
+            boot_time = datetime.now() - timedelta(seconds=uptime_seconds)
+            started_at = boot_time + timedelta(seconds=start_ticks / ticks)
+            uptime = str(datetime.now() - started_at)
+            running = True
+        except Exception:
+            running = False
+    user_count = 0
+    if HTPASSWD_PATH.exists():
+        with HTPASSWD_PATH.open() as f:
+            user_count = sum(1 for _ in f)
+    return ServiceStatus(
+        running=running,
+        pid=pid,
+        uptime=uptime,
+        proxy_port=options.proxy_port,
+        ssl_bump=options.enable_ssl_bump,
+        user_count=user_count,
+    )
+
+
+def ca_metadata() -> dict:
+    if not CA_CERT.exists():
+        raise HTTPException(status_code=404, detail="CA not generated")
+    fingerprint = subprocess.check_output([
+        "openssl",
+        "x509",
+        "-in",
+        str(CA_CERT),
+        "-fingerprint",
+        "-noout",
+    ]).decode().strip()
+    expires = subprocess.check_output([
+        "openssl",
+        "x509",
+        "-in",
+        str(CA_CERT),
+        "-enddate",
+        "-noout",
+    ]).decode().strip()
+    return {"fingerprint": fingerprint, "expires": expires, "cert_path": str(CA_CERT)}
+
+
+def generate_ca() -> dict:
+    if not SSL_DIR.exists():
+        SSL_DIR.mkdir(parents=True, exist_ok=True)
+    for path in (CA_CERT, CA_KEY):
+        if path.exists():
+            backup = path.with_suffix(path.suffix + ".bak")
+            shutil.copy(path, backup)
+    subprocess.run([
+        "openssl",
+        "req",
+        "-new",
+        "-newkey",
+        "rsa:4096",
+        "-days",
+        "3650",
+        "-nodes",
+        "-x509",
+        "-subj",
+        "/CN=Squid Proxy CA",
+        "-keyout",
+        str(CA_KEY),
+        "-out",
+        str(CA_CERT),
+    ], check=True)
+    os.chmod(CA_KEY, 0o600)
+    return ca_metadata()
+
+
+def ensure_ca(options: Options) -> None:
+    if options.enable_ssl_bump and not (CA_CERT.exists() and CA_KEY.exists()):
+        if options.generate_ca_on_first_run:
+            generate_ca()
+        else:
+            raise RuntimeError("SSL bump enabled but CA files are missing")
+
+
+def list_users() -> List[str]:
+    if not HTPASSWD_PATH.exists():
+        return []
+    with HTPASSWD_PATH.open() as f:
+        return [line.split(":", 1)[0] for line in f if line.strip()]
+
+
+def add_or_update_user(user: UserModel) -> None:
+    HTPASSWD_PATH.parent.mkdir(parents=True, exist_ok=True)
+    args = ["htpasswd", "-b", str(HTPASSWD_PATH), user.username, user.password]
+    if not HTPASSWD_PATH.exists():
+        args.insert(1, "-c")
+    subprocess.run(args, check=True)
+
+
+def delete_user(username: str) -> bool:
+    if not HTPASSWD_PATH.exists():
+        return False
+    result = subprocess.run(["htpasswd", "-D", str(HTPASSWD_PATH), username], check=False)
+    if result.returncode == 0:
+        if HTPASSWD_PATH.exists() and HTPASSWD_PATH.stat().st_size == 0:
+            HTPASSWD_PATH.unlink()
+        return True
+    return False
+
+
+async def bootstrap() -> None:
+    await ensure_directories()
+    options = Options.from_file()
+    ensure_ca(options)
+    write_config(options)
+
+
+@app.get("/status", response_model=ServiceStatus)
+def api_status():
+    options = Options.from_file()
+    return service_status(options)
+
+
+@app.post("/start")
+def api_start():
+    options = Options.from_file()
+    ensure_ca(options)
+    start_squid(options)
+    return service_status(options)
+
+
+@app.post("/stop")
+def api_stop():
+    stop_squid()
+    return {"stopped": True}
+
+
+@app.post("/reload")
+def api_reload():
+    options = Options.from_file()
+    reload_squid(options)
+    return {"reloaded": True}
+
+
+@app.post("/ca")
+def api_generate_ca():
+    return generate_ca()
+
+
+@app.get("/ca", response_class=PlainTextResponse)
+def api_download_ca():
+    if not CA_CERT.exists():
+        raise HTTPException(status_code=404, detail="CA not generated")
+    return CA_CERT.read_text()
+
+
+@app.get("/ca/info")
+def api_ca_info():
+    return ca_metadata()
+
+
+@app.get("/logs")
+def api_logs(file: str, lines: int = 50):
+    query = LogQuery(file=file, lines=lines)
+    log_path = LOG_DIR / query.file
+    if not log_path.exists():
+        return []
+    content = log_path.read_text().splitlines()
+    return content[-query.lines :]
+
+
+@app.post("/users")
+def api_users(users: List[UserModel]):
+    # Replace credential set with provided list
+    if not users:
+        if HTPASSWD_PATH.exists():
+            HTPASSWD_PATH.unlink()
+        return {"users": 0}
+    tmp_path = HTPASSWD_PATH.with_suffix(".tmp")
+    for idx, user in enumerate(users):
+        args = ["htpasswd", "-b", str(tmp_path), user.username, user.password]
+        if idx == 0:
+            args.insert(1, "-c")
+        subprocess.run(args, check=True)
+    tmp_path.replace(HTPASSWD_PATH)
+    return {"users": len(users)}
+
+
+@app.get("/users")
+def api_list_users():
+    return list_users()
+
+
+@app.post("/users/add")
+def api_add_user(user: UserModel):
+    add_or_update_user(user)
+    return {"user": user.username}
+
+
+@app.post("/users/delete")
+def api_delete_user(req: UserDeleteRequest):
+    deleted = delete_user(req.username)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"deleted": req.username}
+
+
+@app.post("/options")
+def api_write_options(options: Options):
+    ensure_ca(options)
+    OPTIONS_PATH.write_text(options.model_dump_json(indent=2))
+    reload_squid(options)
+    return options
+
+
+@app.get("/options")
+def api_read_options():
+    return Options.from_file()
+
+
+@app.post("/restart")
+def api_restart():
+    options = Options.from_file()
+    stop_squid()
+    start_squid(options)
+    return service_status(options)
+
+
+@app.get("/", response_class=HTMLResponse)
+def ui_root(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+def parse_cli() -> str:
+    if len(sys.argv) < 2:
+        return "serve"
+    return sys.argv[1]
+
+
+async def serve() -> None:
+    await ensure_directories()
+    options = Options.from_file()
+    ensure_ca(options)
+    start_squid(options)
+    config = {
+        "host": "0.0.0.0",
+        "port": 8099,
+        "reload": False,
+        "log_level": "info",
+        "app": "main:app",
+    }
+    import uvicorn
+
+    uvicorn.run(**config)
+
+
+def main() -> None:
+    command = parse_cli()
+    if command == "bootstrap":
+        asyncio.run(bootstrap())
+    elif command == "serve":
+        asyncio.run(serve())
+    else:
+        raise SystemExit(f"Unknown command {command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,207 @@
+:root {
+  --bg: #0b1e30;
+  --panel: #12283a;
+  --accent: #4dabf7;
+  --text: #e8f0f8;
+  --muted: #9db2c6;
+  --danger: #ef476f;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  margin: 0 auto;
+  padding: 24px;
+  max-width: 1100px;
+}
+
+header h1 {
+  margin: 0 0 4px 0;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-top: 0;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+}
+
+input, textarea, button {
+  font: inherit;
+}
+
+input, textarea {
+  background: #0e1d2b;
+  border: 1px solid #1e3a4f;
+  border-radius: 8px;
+  color: var(--text);
+  padding: 10px;
+}
+
+button {
+  background: var(--accent);
+  color: #0b1e30;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid #2b4c65;
+}
+
+button.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.actions-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.status-grid .label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.status-grid .value {
+  font-weight: 700;
+}
+
+.warning {
+  background: rgba(239, 71, 111, 0.1);
+  border: 1px solid rgba(239, 71, 111, 0.5);
+  padding: 10px;
+  border-radius: 8px;
+  color: var(--text);
+  display: none;
+}
+
+.logs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 12px;
+}
+
+.log-window {
+  background: #0e1d2b;
+  border: 1px solid #1e3a4f;
+  padding: 10px;
+  border-radius: 8px;
+  min-height: 200px;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+
+.form-inline {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+
+.user-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.user-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #0e1d2b;
+  border: 1px solid #1e3a4f;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.info-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.info-list div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: #0e1d2b;
+  border: 1px solid #1e3a4f;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.info-list span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Squid Proxy Manager</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header>
+    <h1>Squid Proxy Manager</h1>
+    <p class="subtitle">Manage proxy status, options, SSL bumping, and users directly from Home Assistant Ingress.</p>
+  </header>
+
+  <section class="panel" id="status-panel">
+    <div class="panel-header">
+      <h2>Service Status</h2>
+      <button id="refresh-status" class="secondary">Refresh</button>
+    </div>
+    <div class="status-grid" id="status-grid"></div>
+    <div class="actions-row">
+      <button id="start-btn">Start</button>
+      <button id="stop-btn" class="danger">Stop</button>
+      <button id="restart-btn">Restart</button>
+      <button id="reload-btn">Reload Config</button>
+    </div>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
+      <h2>Proxy Options</h2>
+      <div class="hint">Changes are validated and applied to Squid immediately.</div>
+    </div>
+    <form id="options-form" class="form-grid">
+      <label>Proxy port
+        <input type="number" id="proxy_port" name="proxy_port" min="1" max="65535" required>
+      </label>
+      <label>Allowed networks (CIDR, one per line)
+        <textarea id="allowed_networks" name="allowed_networks" rows="3" required></textarea>
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" id="enable_auth" name="enable_auth"> Require HTTP Basic Auth
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" id="enable_ssl_bump" name="enable_ssl_bump"> Enable SSL bump (MITM)
+      </label>
+      <label>Cache size (MB)
+        <input type="number" id="cache_size_mb" name="cache_size_mb" min="16" max="10240" required>
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" id="generate_ca_on_first_run" name="generate_ca_on_first_run"> Auto-generate CA when SSL bump enabled
+      </label>
+      <div class="actions-row">
+        <button type="submit">Save & Apply</button>
+      </div>
+      <p class="warning" id="exposure-warning">⚠️ Exposing to a wide network without authentication is unsafe. Enable auth before allowing 0.0.0.0/0.</p>
+    </form>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
+      <h2>HTTPS Certificate</h2>
+      <div class="hint">Generate a dedicated CA for SSL bumping and download the certificate for client devices.</div>
+    </div>
+    <div class="actions-row">
+      <button id="generate-ca">Generate / Regenerate CA</button>
+      <button id="download-ca" class="secondary">Download CA Certificate</button>
+    </div>
+    <dl id="ca-info" class="info-list"></dl>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
+      <h2>User Management</h2>
+      <div class="hint">No default users are created. Add at least one when authentication is enabled.</div>
+    </div>
+    <form id="user-form" class="form-inline">
+      <input type="text" id="user-name" placeholder="Username" required>
+      <input type="password" id="user-pass" placeholder="Password" required>
+      <button type="submit">Add / Update User</button>
+    </form>
+    <ul id="user-list" class="user-list"></ul>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
+      <h2>Logs</h2>
+      <div class="hint">View the latest entries from Squid logs.</div>
+    </div>
+    <div class="logs">
+      <div>
+        <div class="log-header">access.log <button data-log="access.log" class="secondary log-refresh">Refresh</button></div>
+        <pre id="access-log" class="log-window"></pre>
+      </div>
+      <div>
+        <div class="log-header">cache.log <button data-log="cache.log" class="secondary log-refresh">Refresh</button></div>
+        <pre id="cache-log" class="log-window"></pre>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    const statusGrid = document.getElementById('status-grid');
+    const exposureWarning = document.getElementById('exposure-warning');
+
+    function renderStatus(status) {
+      const fields = [
+        ['Running', status.running ? 'Yes' : 'No'],
+        ['PID', status.pid || '–'],
+        ['Uptime', status.uptime || '–'],
+        ['Proxy port', status.proxy_port],
+        ['SSL bump', status.ssl_bump ? 'Enabled' : 'Disabled'],
+        ['User count', status.user_count]
+      ];
+      statusGrid.innerHTML = fields.map(([k,v]) => `<div><div class="label">${k}</div><div class="value">${v}</div></div>`).join('');
+    }
+
+    async function fetchJson(url, options = {}) {
+      const res = await fetch(url, {headers: {'Content-Type': 'application/json'}, ...options});
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || res.statusText);
+      }
+      return res.headers.get('content-type')?.includes('application/json') ? res.json() : res.text();
+    }
+
+    async function loadStatus() {
+      const data = await fetchJson('/status');
+      renderStatus(data);
+    }
+
+    async function loadOptions() {
+      const data = await fetchJson('/options');
+      document.getElementById('proxy_port').value = data.proxy_port;
+      document.getElementById('allowed_networks').value = data.allowed_networks.join('\n');
+      document.getElementById('enable_auth').checked = data.enable_auth;
+      document.getElementById('enable_ssl_bump').checked = data.enable_ssl_bump;
+      document.getElementById('cache_size_mb').value = data.cache_size_mb;
+      document.getElementById('generate_ca_on_first_run').checked = data.generate_ca_on_first_run;
+      exposureWarning.style.display = needsWarning(data) ? 'block' : 'none';
+    }
+
+    function needsWarning(opts) {
+      const openNetwork = opts.allowed_networks.some(n => n.trim() === '0.0.0.0/0');
+      return openNetwork && !opts.enable_auth;
+    }
+
+    document.getElementById('options-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = {
+        proxy_port: Number(document.getElementById('proxy_port').value),
+        allowed_networks: document.getElementById('allowed_networks').value.split(/\n+/).map(s => s.trim()).filter(Boolean),
+        enable_auth: document.getElementById('enable_auth').checked,
+        enable_ssl_bump: document.getElementById('enable_ssl_bump').checked,
+        cache_size_mb: Number(document.getElementById('cache_size_mb').value),
+        generate_ca_on_first_run: document.getElementById('generate_ca_on_first_run').checked
+      };
+      const res = await fetchJson('/options', {method: 'POST', body: JSON.stringify(payload)});
+      exposureWarning.style.display = needsWarning(res) ? 'block' : 'none';
+      await loadStatus();
+      alert('Options saved and applied');
+    });
+
+    document.getElementById('start-btn').addEventListener('click', async () => { await fetchJson('/start', {method: 'POST'}); await loadStatus(); });
+    document.getElementById('stop-btn').addEventListener('click', async () => { await fetchJson('/stop', {method: 'POST'}); await loadStatus(); });
+    document.getElementById('reload-btn').addEventListener('click', async () => { await fetchJson('/reload', {method: 'POST'}); await loadStatus(); });
+    document.getElementById('restart-btn').addEventListener('click', async () => { await fetchJson('/restart', {method: 'POST'}); await loadStatus(); });
+    document.getElementById('refresh-status').addEventListener('click', loadStatus);
+
+    document.getElementById('generate-ca').addEventListener('click', async () => {
+      const info = await fetchJson('/ca', {method: 'POST'});
+      renderCA(info);
+      alert('CA generated. Restart Squid to apply SSL bump.');
+    });
+
+    document.getElementById('download-ca').addEventListener('click', async () => {
+      const res = await fetch('/ca');
+      if (!res.ok) {
+        alert('CA not generated yet');
+        return;
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'squid_ca.pem';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+
+    function renderCA(info) {
+      if (!info || !info.cert_path) {
+        document.getElementById('ca-info').innerHTML = '<li>No CA generated yet.</li>';
+        return;
+      }
+      document.getElementById('ca-info').innerHTML = `
+        <div><span>Certificate path</span><strong>${info.cert_path}</strong></div>
+        <div><span>Fingerprint</span><strong>${info.fingerprint}</strong></div>
+        <div><span>Expiration</span><strong>${info.expires}</strong></div>`;
+    }
+
+    async function loadCA() {
+      try {
+        const info = await fetchJson('/ca/info');
+        renderCA(info);
+      } catch (e) {
+        renderCA(null);
+      }
+    }
+
+    async function loadUsers() {
+      const list = await fetchJson('/users');
+      const container = document.getElementById('user-list');
+      container.innerHTML = '';
+      list.forEach(user => {
+        const li = document.createElement('li');
+        li.textContent = user;
+        const btn = document.createElement('button');
+        btn.textContent = 'Delete';
+        btn.className = 'danger';
+        btn.onclick = async () => {
+          try {
+            await fetchJson('/users/delete', {method: 'POST', body: JSON.stringify({username: user})});
+            await loadUsers();
+            await loadStatus();
+          } catch (err) {
+            alert(err);
+          }
+        };
+        li.appendChild(btn);
+        container.appendChild(li);
+      });
+    }
+
+    document.getElementById('user-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('user-name').value.trim();
+      const password = document.getElementById('user-pass').value.trim();
+      if (!username || !password) return;
+      await fetchJson('/users/add', {method: 'POST', body: JSON.stringify({username, password})});
+      document.getElementById('user-pass').value = '';
+      await loadUsers();
+      await loadStatus();
+    });
+
+    async function loadLog(name) {
+      const lines = await fetchJson(`/logs?file=${encodeURIComponent(name)}&lines=200`);
+      const target = name === 'access.log' ? document.getElementById('access-log') : document.getElementById('cache-log');
+      target.textContent = Array.isArray(lines) ? lines.join('\n') : lines;
+    }
+
+    document.querySelectorAll('.log-refresh').forEach(btn => {
+      btn.addEventListener('click', () => loadLog(btn.dataset.log));
+    });
+
+    async function init() {
+      await Promise.all([loadOptions(), loadStatus(), loadUsers(), loadLog('access.log'), loadLog('cache.log')]);
+      loadCA();
+      setInterval(loadStatus, 10000);
+    }
+
+    init().catch(err => alert(err));
+  </script>
+</body>
+</html>

--- a/app/templates/squid.conf.j2
+++ b/app/templates/squid.conf.j2
@@ -1,0 +1,42 @@
+pid_filename {{ pid_file }}
+
+http_port {{ options.proxy_port }}{% if options.enable_ssl_bump %} ssl-bump cert={{ ca_cert }} key={{ ca_key }} generate-host-certificates=on dynamic_cert_mem_cache_size=16MB{% endif %}
+
+cache_dir ufs {{ cache_dir }} {{ options.cache_size_mb }} 16 256
+access_log stdio:{{ log_dir }}/access.log
+cache_log {{ log_dir }}/cache.log
+coredump_dir {{ cache_dir }}
+visible_hostname squid-proxy
+
+acl localnet src {{ ' '.join(options.allowed_networks) }}
+acl SSL_ports port 443
+acl Safe_ports port 80# http
+acl Safe_ports port 443# https
+acl Safe_ports port 1025-65535# unregistered ports
+
+{% if options.enable_auth %}
+auth_param basic program /usr/lib/squid/basic_ncsa_auth {{ htpasswd }}
+auth_param basic realm Squid proxy authentication
+acl authenticated proxy_auth REQUIRED
+{% endif %}
+
+{% if options.enable_ssl_bump %}
+acl step1 at_step SslBump1
+ssl_bump peek step1
+ssl_bump bump all
+http_access deny !SSL_ports
+{% endif %}
+
+{% if options.enable_auth %}
+http_access allow authenticated localnet
+http_access deny authenticated
+{% else %}
+http_access allow localnet
+{% endif %}
+http_access deny all
+
+forwarded_for delete
+request_header_access Allow allow all
+request_header_access Authorization allow all
+request_header_access WWW-Authenticate allow all
+request_header_access All deny all

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,42 @@
+name: "Squid Proxy"
+version: "0.1.0"
+description: "Home Assistant add-on providing Squid HTTP/HTTPS proxy with management UI."
+url: "https://example.com/ha-squid-proxy"
+starter: false
+slug: "squid_proxy"
+arch:
+  - amd64
+  - armv7
+  - armhf
+  - aarch64
+  - i386
+ingress: true
+ingress_port: 0
+panel_icon: "mdi:proxy"
+startup: services
+boot: auto
+auth_api: true
+homeassistant_api: false
+host_network: false
+privileged:
+  - NET_ADMIN
+  - DAC_READ_SEARCH
+map:
+  - ssl:rw
+  - data:rw
+options:
+  proxy_port: 3128
+  allowed_networks:
+    - 127.0.0.1/32
+  enable_auth: false
+  enable_ssl_bump: false
+  cache_size_mb: 512
+  generate_ca_on_first_run: false
+schema:
+  proxy_port: int
+  allowed_networks:
+    - str
+  enable_auth: bool
+  enable_ssl_bump: bool
+  cache_size_mb: int
+  generate_ca_on_first_run: bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.6.3
+jinja2==3.1.3

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bashio
+set -euo pipefail
+
+bashio::log.info "Preparing Squid proxy add-on"
+python3 /app/main.py bootstrap
+
+bashio::log.info "Starting management API and Squid"
+exec python3 /app/main.py serve


### PR DESCRIPTION
## Summary
- add ingress-friendly HTML/CSS UI for managing Squid status, options, certificates, users, and logs
- extend FastAPI management API with restart, CA metadata, and granular user operations used by the UI
- update documentation to describe the new ingress interface and lifecycle controls

## Testing
- python3 -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b48e9e508323b1bd8bbda4976edb)