### PR TITLE
feat: v1.6.9 — external address in dialog, port fix, editable diff preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.6.9] - 2026-02-17
+
+### Changed
+- **External Address** moved from instance settings to OpenVPN Patcher dialog where it's actually used
+- **DPI evasion settings** now injected near the top of patched .ovpn files (right after `remote`) for better visibility
+- Patched config preview now shows **embedded diff highlighting**: green for added lines, red strikethrough for removed directives
+- Patched config preview is now **editable** with OpenVPN syntax highlighting (keywords, comments, numbers, strings)
+- Download filename is now **customizable** via a text field (defaults to `{instance}_patched.ovpn`)
+
+### Added
+- **DPI prevention settings** automatically added to TLS tunnel patched configs: `proto tcp`, `tun-mtu 1500`, `mssfix 1300`, `sndbuf 0`, `rcvbuf 0`, `connect-retry-max 100`, `float`
+- UDP-only directives (`explicit-exit-notify`) are commented out with explanation when patching for TLS tunnel
+- External address input in dialog shows error (TLS tunnel) or warning (Squid) when empty
+- External address supports `host:port` format — port is automatically parsed and used in patched config
+
+### Fixed
+- **Port duplication bug**: external address like `rbnkv.com:4443` no longer produces `remote rbnkv.com:4443 8443`
+- Syntax highlighting overlay alignment fixed (border on container, not textarea)
+
+### Removed
+- External IP and External Port fields from General settings tab (moved to dialog)
+
 ## [1.6.5] - 2026-02-13
 
 ### Changed

--- a/pre_release_scripts/record_workflows_impl.py
+++ b/pre_release_scripts/record_workflows_impl.py
@@ -12,11 +12,13 @@ Workflows recorded:
 1. Add first proxy to empty dashboard + add users + test connectivity
 2. Add HTTPS proxy + add users + test connectivity
 3. Create TLS Tunnel instance + show dashboard + settings + Connection Info + Cover Site
+4. OpenVPN patcher: upload .ovpn, patch with DPI settings, show diff preview
 
 Generated GIFs:
 - 00-add-first-proxy.gif (from workflow 1)
 - 01-add-https-proxy.gif (from workflow 2)
 - 02-tls-tunnel.gif (from workflow 3)
+- 03-ovpn-patcher.gif (from workflow 4)
 
 Saved to: docs/gifs/
 """
@@ -292,8 +294,9 @@ async def workflow_1_add_first_proxy(page: Page, screenshots_dir: Path) -> list:
     await slow_sleep(0.5)
     await fill_field(page, "user-password-input", "password123")
     await slow_sleep(0.5)
+    await page.wait_for_selector('[data-testid="user-add-button"]:not([disabled])', timeout=5000)
     await page.click('[data-testid="user-add-button"]')
-    await slow_sleep(0.8)
+    await slow_sleep(1.5)
     await capture_and_pause(capture)
 
     # Add second user - bob
@@ -302,8 +305,9 @@ async def workflow_1_add_first_proxy(page: Page, screenshots_dir: Path) -> list:
     await slow_sleep(0.5)
     await fill_field(page, "user-password-input", "password456")
     await slow_sleep(0.5)
+    await page.wait_for_selector('[data-testid="user-add-button"]:not([disabled])', timeout=5000)
     await page.click('[data-testid="user-add-button"]')
-    await slow_sleep(0.8)
+    await slow_sleep(1.5)
     await capture_and_pause(capture)
 
     # Scroll to Test Connectivity section
@@ -429,8 +433,9 @@ async def workflow_2_add_https_proxy(page: Page, screenshots_dir: Path) -> list:
     await slow_sleep(0.5)
     await fill_field(page, "user-password-input", "secret123")
     await slow_sleep(0.5)
+    await page.wait_for_selector('[data-testid="user-add-button"]:not([disabled])', timeout=5000)
     await page.click('[data-testid="user-add-button"]')
-    await slow_sleep(0.8)
+    await slow_sleep(1.5)
     await capture_and_pause(capture)
 
     # Test connectivity
@@ -571,6 +576,118 @@ async def workflow_3_tls_tunnel(page: Page, screenshots_dir: Path) -> list:
     return screenshots
 
 
+async def workflow_4_ovpn_patcher(page: Page, screenshots_dir: Path, repo_root: Path) -> list:
+    """
+    Workflow 4: OpenVPN Config Patcher — upload, patch with DPI, show diff preview
+
+    Steps:
+    1. Navigate to vpn-tunnel settings (created by workflow 3)
+    2. Click "Patch OpenVPN Config" from Connection Info
+    3. Fill external address
+    4. Upload .ovpn fixture file
+    5. Click "Extract & Patch"
+    6. Show diff-highlighted preview with DPI settings
+    7. Show download filename field
+    8. Close dialog
+    """
+    print("Recording Workflow 4: OpenVPN Config Patcher...")
+
+    screenshots = []
+    screenshot_num = 0
+
+    async def capture():
+        nonlocal screenshot_num
+        path = screenshots_dir / f"workflow4_{str(screenshot_num).zfill(3)}.png"
+        await page.screenshot(path=str(path))
+        screenshots.append(str(path))
+        screenshot_num += 1
+        await slow_sleep(0.35)
+
+    # Navigate back to dashboard
+    print("  -> Navigate to dashboard...")
+    await page.go_back()
+    await slow_sleep(1.5)
+    await page.wait_for_selector(
+        '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+        state="visible",
+        timeout=10000,
+    )
+    await capture_and_pause(capture)
+
+    # Navigate to vpn-tunnel settings
+    print("  -> Open vpn-tunnel settings...")
+    await page.click('[data-testid="instance-settings-chip-vpn-tunnel"]')
+    await slow_sleep(1.2)
+    await wait_for_element(page, '[data-testid="settings-tabs"]')
+    await capture_and_pause(capture)
+
+    # Scroll to and click "Patch OpenVPN Config" button
+    print("  -> Open OpenVPN Patcher dialog...")
+    patcher_button = page.locator('[data-testid="connection-info-openvpn-button"]')
+    if await patcher_button.count():
+        await patcher_button.scroll_into_view_if_needed()
+        await slow_sleep(0.5)
+        await patcher_button.click()
+    await slow_sleep(1.2)
+    await capture_and_pause(capture)
+
+    # Fill external address
+    print("  -> Fill external address...")
+    await fill_field(page, "openvpn-external-address-input", "proxy.example.com:8443")
+    await slow_sleep(0.8)
+    await capture_and_pause(capture)
+
+    # Upload .ovpn fixture file
+    print("  -> Upload .ovpn file...")
+    ovpn_fixture = repo_root / "tests" / "fixtures" / "sample_ovpn" / "tls_tunnel_config.ovpn"
+    if ovpn_fixture.exists():
+        file_input = await page.query_selector('[data-testid="openvpn-file-input"]')
+        if file_input:
+            await file_input.set_input_files(str(ovpn_fixture))
+            await slow_sleep(1.2)
+    await capture_and_pause(capture)
+
+    # Click "Extract & Patch" button
+    print("  -> Click Extract & Patch...")
+    patch_button = page.locator('[data-testid="openvpn-patch-button"]')
+    if await patch_button.count() and not await patch_button.is_disabled():
+        await patch_button.click()
+        await slow_sleep(3)
+    await capture_and_pause(capture)
+
+    # Wait for preview with diff highlighting
+    print("  -> Show patched config with diff...")
+    try:
+        await page.wait_for_selector('[data-testid="openvpn-preview"]', timeout=10000)
+        # Scroll to see preview
+        preview = page.locator('[data-testid="openvpn-preview"]')
+        if await preview.count():
+            await preview.scroll_into_view_if_needed()
+        await slow_sleep(1.5)
+    except Exception:
+        print("  Preview not found, continuing...")
+    await capture_and_pause(capture)
+
+    # Show download filename field
+    print("  -> Show download filename field...")
+    filename_field = page.locator('[data-testid="openvpn-download-filename"]')
+    if await filename_field.count():
+        await filename_field.scroll_into_view_if_needed()
+        await slow_sleep(0.8)
+    await capture_and_pause(capture)
+
+    # Close dialog
+    print("  -> Close dialog...")
+    close_button = page.locator('[data-testid="openvpn-dialog-close"]')
+    if await close_button.count():
+        await close_button.click()
+        await slow_sleep(1)
+    await capture_and_pause(capture)
+
+    print(f"  Workflow 4 recorded: {len(screenshots)} frames")
+    return screenshots
+
+
 async def main():
     """Record all workflows and generate GIFs."""
     addon_url = os.environ.get("ADDON_URL", "http://localhost:8099")
@@ -640,6 +757,16 @@ async def main():
             page,
             screenshots3,
             str(gifs_dir / "02-tls-tunnel.gif"),
+        )
+
+        print()
+
+        # Workflow 4: OpenVPN Config Patcher
+        screenshots4 = await workflow_4_ovpn_patcher(page, frames_dir, repo_root)
+        await stop_recording_and_create_gif(
+            page,
+            screenshots4,
+            str(gifs_dir / "03-ovpn-patcher.gif"),
         )
 
         print()

--- a/squid_proxy_manager/Dockerfile
+++ b/squid_proxy_manager/Dockerfile
@@ -22,7 +22,7 @@ LABEL \
     io.hass.name="Squid Proxy Manager" \
     io.hass.description="Manage multiple Squid proxy instances" \
     io.hass.type="addon" \
-    io.hass.version="1.6.8"
+    io.hass.version="1.6.9"
 
 # Set working directory
 WORKDIR /app

--- a/squid_proxy_manager/config.yaml
+++ b/squid_proxy_manager/config.yaml
@@ -1,6 +1,6 @@
 name: Squid Proxy Manager
 description: Manage multiple Squid proxy instances with HTTPS support and basic authentication
-version: "1.6.8"
+version: "1.6.9"
 slug: squid_proxy_manager
 url: "https://github.com/rybnikov/HA_SQUID_PROXY"
 init: false

--- a/squid_proxy_manager/frontend/package.json
+++ b/squid_proxy_manager/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-proxy-manager-ui",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/squid_proxy_manager/frontend/src/features/instances/InstanceSettingsPage.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/InstanceSettingsPage.tsx
@@ -64,15 +64,10 @@ export function InstanceSettingsPage() {
   const [httpsEnabled, setHttpsEnabled] = useState<boolean | null>(null);
   const [forwardAddress, setForwardAddress] = useState<string | null>(null);
   const [coverDomain, setCoverDomain] = useState<string | null>(null);
-  const [externalIp, setExternalIp] = useState<string | null>(null);
-  const [externalPort, setExternalPort] = useState<number | null>(null);
-
   const resolvedPort = port ?? instance?.port ?? 3128;
   const resolvedHttpsEnabled = httpsEnabled ?? instance?.https_enabled ?? false;
   const resolvedForwardAddress = forwardAddress ?? instance?.forward_address ?? '';
   const resolvedCoverDomain = coverDomain ?? instance?.cover_domain ?? '';
-  const resolvedExternalIp = externalIp ?? instance?.external_ip ?? '';
-  const resolvedExternalPort = externalPort ?? instance?.external_port;
 
   const isRunning = instance?.running ?? instance?.status === 'running';
   const proxyType = instance?.proxy_type ?? 'squid';
@@ -210,12 +205,8 @@ export function InstanceSettingsPage() {
                 proxyType={proxyType}
                 forwardAddress={resolvedForwardAddress}
                 coverDomain={resolvedCoverDomain}
-                externalIp={resolvedExternalIp}
-                externalPort={resolvedExternalPort}
                 onForwardAddressChange={setForwardAddress}
                 onCoverDomainChange={setCoverDomain}
-                onExternalIpChange={setExternalIp}
-                onExternalPortChange={setExternalPort}
               />
             </div>
           </HACard>
@@ -239,7 +230,7 @@ export function InstanceSettingsPage() {
           {!isTlsTunnel && (
             <HACard title="Test Connectivity">
               <div style={{ padding: '16px' }}>
-                <TestTab instanceName={instance.name} port={resolvedPort} externalIp={resolvedExternalIp} />
+                <TestTab instanceName={instance.name} port={resolvedPort} />
               </div>
             </HACard>
           )}
@@ -251,8 +242,6 @@ export function InstanceSettingsPage() {
                   instanceName={instance.name}
                   port={resolvedPort}
                   forwardAddress={resolvedForwardAddress}
-                  externalIp={resolvedExternalIp}
-                  externalPort={resolvedExternalPort}
                 />
               </div>
             </HACard>

--- a/squid_proxy_manager/frontend/src/features/instances/OpenVPNPatcherDialog.test.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/OpenVPNPatcherDialog.test.tsx
@@ -1,11 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react';
+import React from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import * as instancesApi from '@/api/instances';
-
 import { OpenVPNPatcherDialog } from './OpenVPNPatcherDialog';
+
+import * as instancesApi from '@/api/instances';
 
 // Mock the API module
 vi.mock('@/api/instances', () => ({
@@ -285,17 +285,45 @@ describe('OpenVPNPatcherDialog', () => {
   });
 
   describe('P2 - Edge Cases', () => {
-    it('shows external IP warning when missing', () => {
-      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} externalIp={undefined} />);
+    it('shows external address warning for squid when empty', () => {
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
 
-      expect(screen.getByText(/External IP not set/i)).toBeTruthy();
-      expect(screen.getByText(/General settings/i)).toBeTruthy();
+      expect(screen.getByText(/External address not set/i)).toBeTruthy();
     });
 
-    it('hides external IP warning when provided', () => {
-      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} externalIp="1.2.3.4" />);
+    it('hides external address warning when filled in', async () => {
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
 
-      expect(screen.queryByText(/External IP not set/i)).toBeNull();
+      // Fill in external address
+      const addressInput = screen.getByTestId('openvpn-external-address-input')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.input(addressInput, { target: { value: '1.2.3.4' } });
+
+      await waitFor(() => {
+        expect(screen.queryByText(/External address not set/i)).toBeNull();
+      });
+    });
+
+    it('shows error card for TLS tunnel when external address empty', () => {
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} proxyType="tls_tunnel" />);
+
+      expect(screen.getByTestId('openvpn-external-ip-error')).toBeTruthy();
+    });
+
+    it('disables patch button for TLS tunnel when external address empty', () => {
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} proxyType="tls_tunnel" />);
+
+      // Upload a file first
+      const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
+      const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
+      Object.defineProperty(fileInput, 'files', {
+        value: [mockFile],
+        writable: false,
+      });
+      fireEvent.change(fileInput);
+
+      const patchButton = screen.getByTestId('openvpn-patch-button') as HTMLButtonElement;
+      expect(patchButton.disabled).toBe(true);
     });
 
     it('copy success message appears after copy', async () => {
@@ -402,16 +430,19 @@ describe('OpenVPNPatcherDialog', () => {
       expect(patchButton.disabled).toBe(false);
     });
 
-    it('calls patchOVPNConfig when patch button clicked', async () => {
+    it('calls patchOVPNConfig with external address when provided', async () => {
       const mockPatchedContent = 'client\nhttp-proxy 192.168.1.100 3128\ndev tun\n';
       vi.mocked(instancesApi.patchOVPNConfig).mockResolvedValue({
         patched_content: mockPatchedContent,
         filename: 'test_patched.ovpn',
       });
 
-      renderWithQueryClient(
-        <OpenVPNPatcherDialog {...defaultProps} externalIp="192.168.1.100" />
-      );
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      // Fill in external address
+      const addressInput = screen.getByTestId('openvpn-external-address-input')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.input(addressInput, { target: { value: '192.168.1.100' } });
 
       const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
       const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
@@ -435,6 +466,38 @@ describe('OpenVPNPatcherDialog', () => {
       expect(instancesApi.patchOVPNConfig).toHaveBeenCalledWith('test-instance', {
         file: mockFile,
         external_host: '192.168.1.100',
+      });
+    });
+
+    it('calls patchOVPNConfig without external_host when address empty', async () => {
+      const mockPatchedContent = 'client\nhttp-proxy localhost 3128\ndev tun\n';
+      vi.mocked(instancesApi.patchOVPNConfig).mockResolvedValue({
+        patched_content: mockPatchedContent,
+        filename: 'test_patched.ovpn',
+      });
+
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
+      const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
+
+      Object.defineProperty(fileInput, 'files', {
+        value: [mockFile],
+        writable: false,
+      });
+
+      fireEvent.change(fileInput);
+
+      const patchButton = screen.getByTestId('openvpn-patch-button');
+      fireEvent.click(patchButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('openvpn-preview')).toBeTruthy();
+      }, { timeout: 3000 });
+
+      // Check that API was called without external_host
+      expect(instancesApi.patchOVPNConfig).toHaveBeenCalledWith('test-instance', {
+        file: mockFile,
       });
     });
 
@@ -547,6 +610,67 @@ describe('OpenVPNPatcherDialog', () => {
       await waitFor(() => {
         const preview = screen.getByTestId('openvpn-preview') as HTMLTextAreaElement;
         expect(preview.value).toBe(mockPatchedContent);
+      });
+    });
+
+    it('preview is editable', async () => {
+      const mockPatchedContent = 'client\ndev tun\n';
+      vi.mocked(instancesApi.patchOVPNConfig).mockResolvedValue({
+        patched_content: mockPatchedContent,
+        filename: 'test_patched.ovpn',
+      });
+
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      // Upload and patch
+      const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
+      const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
+      Object.defineProperty(fileInput, 'files', {
+        value: [mockFile],
+        writable: false,
+      });
+      fireEvent.change(fileInput);
+
+      const patchButton = screen.getByTestId('openvpn-patch-button');
+      fireEvent.click(patchButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('openvpn-preview')).toBeTruthy();
+      });
+
+      // Edit the preview
+      const preview = screen.getByTestId('openvpn-preview') as HTMLTextAreaElement;
+      fireEvent.change(preview, { target: { value: 'client\ndev tun\n# my edit\n' } });
+
+      expect(preview.value).toBe('client\ndev tun\n# my edit\n');
+    });
+
+    it('preview has syntax highlighting overlay', async () => {
+      const mockPatchedContent = 'client\ndev tun\n';
+      vi.mocked(instancesApi.patchOVPNConfig).mockResolvedValue({
+        patched_content: mockPatchedContent,
+        filename: 'test_patched.ovpn',
+      });
+
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      // Upload and patch
+      const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
+      const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
+      Object.defineProperty(fileInput, 'files', {
+        value: [mockFile],
+        writable: false,
+      });
+      fireEvent.change(fileInput);
+
+      const patchButton = screen.getByTestId('openvpn-patch-button');
+      fireEvent.click(patchButton);
+
+      await waitFor(() => {
+        const highlight = screen.getByTestId('openvpn-preview-highlight');
+        expect(highlight).toBeTruthy();
+        // Check that syntax highlighting applied keyword classes
+        expect(highlight.innerHTML).toContain('ovpn-keyword');
       });
     });
 
@@ -780,7 +904,7 @@ describe('OpenVPNPatcherDialog', () => {
           filename: 'test_patched.ovpn',
         });
 
-        const { rerender } = renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+        renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
 
         // Upload and patch first file
         const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
@@ -847,6 +971,68 @@ describe('OpenVPNPatcherDialog', () => {
 
         expect(defaultProps.onClose).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('External Address Input', () => {
+    it('renders external address input field', () => {
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('openvpn-external-address-input')).toBeTruthy();
+    });
+
+    it('sends external_host with host:port format', async () => {
+      const mockPatchedContent = 'client\nhttp-proxy proxy.example.com 4443\ndev tun\n';
+      vi.mocked(instancesApi.patchOVPNConfig).mockResolvedValue({
+        patched_content: mockPatchedContent,
+        filename: 'test_patched.ovpn',
+      });
+
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} />);
+
+      // Fill in external address with port
+      const addressInput = screen.getByTestId('openvpn-external-address-input')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.input(addressInput, { target: { value: 'proxy.example.com:4443' } });
+
+      // Upload file
+      const fileInput = screen.getByTestId('openvpn-file-input') as HTMLInputElement;
+      const mockFile = new File(['client\ndev tun\n'], 'test.ovpn', { type: 'text/plain' });
+      Object.defineProperty(fileInput, 'files', {
+        value: [mockFile],
+        writable: false,
+      });
+      fireEvent.change(fileInput);
+
+      // Click patch
+      const patchButton = screen.getByTestId('openvpn-patch-button');
+      fireEvent.click(patchButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('openvpn-preview')).toBeTruthy();
+      }, { timeout: 3000 });
+
+      // Verify the full host:port string was sent
+      expect(instancesApi.patchOVPNConfig).toHaveBeenCalledWith('test-instance', {
+        file: mockFile,
+        external_host: 'proxy.example.com:4443',
+      });
+    });
+
+    it('resets external address when dialog is closed', async () => {
+      const onClose = vi.fn();
+      renderWithQueryClient(<OpenVPNPatcherDialog {...defaultProps} onClose={onClose} />);
+
+      // Fill in external address
+      const addressInput = screen.getByTestId('openvpn-external-address-input')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.input(addressInput, { target: { value: '1.2.3.4' } });
+
+      // Close dialog
+      const closeButton = screen.getByTestId('openvpn-dialog-close');
+      fireEvent.click(closeButton);
+
+      expect(onClose).toHaveBeenCalled();
     });
   });
 });

--- a/squid_proxy_manager/frontend/src/features/instances/OpenVPNPatcherDialog.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/OpenVPNPatcherDialog.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { getUsers, patchOVPNConfig } from '@/api/instances';
 import { HAButton, HACard, HADialog, HAIcon, HASelect, HASwitch, HATextField } from '@/ui/ha-wrappers';
@@ -14,7 +14,110 @@ interface OpenVPNPatcherDialogProps {
   instanceName: string;
   proxyType: 'squid' | 'tls_tunnel';
   port: number;
-  externalIp?: string;
+}
+
+// OpenVPN config keywords for syntax highlighting
+const OVPN_KEYWORDS = new Set([
+  'client', 'dev', 'proto', 'remote', 'resolv-retry', 'nobind',
+  'persist-key', 'persist-tun', 'cipher', 'auth', 'verb',
+  'tls-crypt', 'tls-auth', 'ca', 'cert', 'key',
+  'http-proxy', 'route', 'redirect-gateway', 'keepalive',
+  'comp-lzo', 'remote-cert-tls', 'pull', 'tun-mtu', 'float',
+  'http-proxy-option', 'http-proxy-retry', 'tls-timeout',
+  'connect-retry-max', 'server', 'ifconfig', 'push',
+  'topology', 'sndbuf', 'rcvbuf', 'mssfix',
+]);
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Compute which line indices in `patched` are new (not in `original`) using LCS. */
+function computeAddedLines(original: string, patched: string): Set<number> {
+  const origLines = original.split('\n');
+  const patchLines = patched.split('\n');
+  const m = origLines.length;
+  const n = patchLines.length;
+
+  // LCS dynamic programming
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (origLines[i - 1] === patchLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack to find added lines in patched
+  const added = new Set<number>();
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (origLines[i - 1] === patchLines[j - 1]) {
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--; // removed from original
+    } else {
+      added.add(j - 1); // added in patched
+      j--;
+    }
+  }
+  while (j > 0) {
+    added.add(j - 1);
+    j--;
+  }
+
+  return added;
+}
+
+function highlightOvpn(text: string, addedLines?: Set<number>): string {
+  return text
+    .split('\n')
+    .map((line, idx) => {
+      let highlighted: string;
+
+      // Comment lines
+      if (line.trimStart().startsWith('#') || line.trimStart().startsWith(';')) {
+        highlighted = `<span class="ovpn-comment">${escapeHtml(line)}</span>`;
+      // Inline tags like <ca>, </ca>, <cert>, etc.
+      } else if (/^\s*<\/?[a-zA-Z-]+>\s*$/.test(line)) {
+        highlighted = `<span class="ovpn-keyword">${escapeHtml(line)}</span>`;
+      } else {
+        // Tokenize the line
+        highlighted = line.replace(
+          /("(?:[^"\\]|\\.)*")|('(?:[^'\\]|\\.)*')|(\b\d+\b)|([a-zA-Z][a-zA-Z0-9_-]*)/g,
+          (match, doubleStr, singleStr, num, word) => {
+            if (doubleStr || singleStr) {
+              return `<span class="ovpn-string">${escapeHtml(match)}</span>`;
+            }
+            if (num) {
+              return `<span class="ovpn-number">${escapeHtml(match)}</span>`;
+            }
+            if (word && OVPN_KEYWORDS.has(word)) {
+              return `<span class="ovpn-keyword">${escapeHtml(match)}</span>`;
+            }
+            return escapeHtml(match);
+          }
+        );
+      }
+
+      // Wrap with diff background if this line was added/changed
+      if (addedLines?.has(idx)) {
+        const isRemovedDirective = line.includes('# removed for');
+        const cls = isRemovedDirective ? 'ovpn-diff-removed' : 'ovpn-diff-added';
+        highlighted = `<span class="${cls}">${highlighted}</span>`;
+      }
+
+      return highlighted;
+    })
+    .join('\n');
 }
 
 export function OpenVPNPatcherDialog({
@@ -22,7 +125,6 @@ export function OpenVPNPatcherDialog({
   onClose,
   instanceName,
   proxyType,
-  externalIp,
 }: OpenVPNPatcherDialogProps) {
   const queryClient = useQueryClient();
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
@@ -35,6 +137,25 @@ export function OpenVPNPatcherDialog({
   const [copySuccess, setCopySuccess] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [extractedVpnServer, setExtractedVpnServer] = useState<string | null>(null);
+  const [externalAddress, setExternalAddress] = useState('');
+  const [downloadFilename, setDownloadFilename] = useState(`${instanceName}_patched.ovpn`);
+  const [originalContent, setOriginalContent] = useState<string | null>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  // Compute diff between original and patched content
+  const addedLines = useMemo(() => {
+    if (!originalContent || !patchedContent) return undefined;
+    return computeAddedLines(originalContent, patchedContent);
+  }, [originalContent, patchedContent]);
+
+  // Read file text for diff comparison
+  const readFileForDiff = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      setOriginalContent(ev.target?.result as string);
+    };
+    reader.readAsText(file);
+  };
 
   // Fetch users for Squid instances
   const usersQuery = useQuery({
@@ -53,7 +174,7 @@ export function OpenVPNPatcherDialog({
         username?: string;
         password?: string;
       } = { file: uploadedFile };
-      if (externalIp) payload.external_host = externalIp;
+      if (externalAddress) payload.external_host = externalAddress;
 
       // For Squid, include auth if enabled
       if (proxyType === 'squid' && includeAuth && selectedUsername && manualPassword) {
@@ -87,6 +208,7 @@ export function OpenVPNPatcherDialog({
         setUploadedFile(file);
         setPatchedContent(null); // Reset preview
         setFileError(null);
+        readFileForDiff(file);
       } else {
         setFileError('Please select a valid .ovpn file');
         setUploadedFile(null);
@@ -117,6 +239,7 @@ export function OpenVPNPatcherDialog({
         setUploadedFile(file);
         setPatchedContent(null);
         setFileError(null);
+        readFileForDiff(file);
       } else {
         setFileError('Please select a valid .ovpn file');
         setUploadedFile(null);
@@ -131,7 +254,7 @@ export function OpenVPNPatcherDialog({
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${instanceName}_patched.ovpn`;
+    a.download = downloadFilename || `${instanceName}_patched.ovpn`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -154,10 +277,21 @@ export function OpenVPNPatcherDialog({
     setManualPassword('');
     setIncludeAuth(false);
     setExtractedVpnServer(null);
+    setExternalAddress('');
+    setDownloadFilename(`${instanceName}_patched.ovpn`);
+    setOriginalContent(null);
     // Reset mutation state to clear any previous errors
     patchMutation.reset();
     onClose();
   };
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLTextAreaElement>) => {
+    const target = e.currentTarget;
+    if (preRef.current) {
+      preRef.current.scrollTop = target.scrollTop;
+      preRef.current.scrollLeft = target.scrollLeft;
+    }
+  }, []);
 
   const users: User[] = usersQuery.data?.users ?? [];
 
@@ -171,6 +305,16 @@ export function OpenVPNPatcherDialog({
       data-testid="openvpn-dialog"
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', padding: '16px' }}>
+        {/* Syntax highlighting styles */}
+        <style>{`
+          .ovpn-keyword { color: var(--primary-color, #03a9f4); }
+          .ovpn-comment { color: var(--secondary-text-color, #9b9b9b); font-style: italic; }
+          .ovpn-string { color: var(--success-color, #4caf50); }
+          .ovpn-number { color: var(--warning-color, #ff9800); }
+          .ovpn-diff-added { background: rgba(76, 175, 80, 0.18); }
+          .ovpn-diff-removed { background: rgba(219, 68, 55, 0.18); text-decoration: line-through; }
+        `}</style>
+
         {/* Info Card */}
         <HACard outlined>
           <div style={{ padding: '12px', display: 'flex', gap: '12px' }}>
@@ -183,32 +327,36 @@ export function OpenVPNPatcherDialog({
           </div>
         </HACard>
 
-        {/* External IP Warning/Error (conditional) */}
-        {!externalIp && proxyType === 'tls_tunnel' && (
+        {/* External Address Input */}
+        <HATextField
+          label="External Address"
+          value={externalAddress}
+          onChange={(e) => setExternalAddress(e.target.value)}
+          placeholder="proxy.example.com or proxy.example.com:4443"
+          helperText="Your server's public IP or hostname. Include :port if different from listen port."
+          data-testid="openvpn-external-address-input"
+        />
+
+        {/* External Address Warning/Error (conditional) */}
+        {!externalAddress && proxyType === 'tls_tunnel' && (
           <HACard outlined style={{ borderLeft: '4px solid var(--error-color)' }} data-testid="openvpn-external-ip-error">
             <div style={{ padding: '12px', display: 'flex', gap: '12px' }}>
               <HAIcon icon="mdi:alert-circle" style={{ flexShrink: 0, color: 'var(--error-color)' }} />
               <div style={{ fontSize: '14px' }}>
-                <p style={{ margin: '0 0 8px 0', color: 'var(--error-color)' }}>
-                  External IP is required. Without it, the patched config will contain &quot;localhost&quot; which won&apos;t work for clients connecting to this tunnel.
-                </p>
-                <p style={{ fontWeight: 500, margin: 0 }}>
-                  Action: Set external IP in General settings before patching.
+                <p style={{ margin: 0, color: 'var(--error-color)' }}>
+                  External address is required for TLS tunnel. Without it, the patched config will contain &quot;localhost&quot; which won&apos;t work for clients connecting to this tunnel.
                 </p>
               </div>
             </div>
           </HACard>
         )}
-        {!externalIp && proxyType === 'squid' && (
+        {!externalAddress && proxyType === 'squid' && (
           <HACard outlined style={{ borderLeft: '4px solid var(--warning-color)' }}>
             <div style={{ padding: '12px', display: 'flex', gap: '12px' }}>
               <HAIcon icon="mdi:alert" style={{ flexShrink: 0 }} />
               <div style={{ fontSize: '14px' }}>
-                <p style={{ margin: '0 0 8px 0' }}>
-                  External IP not set. Config will use &quot;localhost&quot; which only works for local testing.
-                </p>
-                <p style={{ fontWeight: 500, margin: 0 }}>
-                  Action: Set external IP in General settings.
+                <p style={{ margin: 0 }}>
+                  External address not set. Config will use &quot;localhost&quot; which only works for local testing.
                 </p>
               </div>
             </div>
@@ -325,7 +473,7 @@ export function OpenVPNPatcherDialog({
           <HAButton
             variant="primary"
             onClick={() => patchMutation.mutate()}
-            disabled={!uploadedFile || patchMutation.isPending || (proxyType === 'tls_tunnel' && !externalIp)}
+            disabled={!uploadedFile || patchMutation.isPending || (proxyType === 'tls_tunnel' && !externalAddress)}
             loading={patchMutation.isPending}
             data-testid="openvpn-patch-button"
           >
@@ -351,26 +499,76 @@ export function OpenVPNPatcherDialog({
           </HACard>
         )}
 
-        {/* Preview Section (after patch) */}
+        {/* Preview Section (after patch) - editable with syntax highlighting */}
         {patchedContent && (
           <HACard header="Patched Config Preview">
             <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              <textarea
-                readOnly
-                value={patchedContent}
-                style={{
-                  width: '100%',
-                  height: '300px',
-                  fontFamily: 'monospace',
-                  fontSize: '12px',
-                  padding: '12px',
-                  border: '1px solid var(--divider-color)',
-                  borderRadius: '8px',
-                  backgroundColor: 'var(--secondary-background-color)',
-                  color: 'var(--primary-text-color)',
-                  resize: 'vertical',
-                }}
-                data-testid="openvpn-preview"
+              <div style={{
+                position: 'relative',
+                minHeight: '300px',
+                border: '1px solid var(--divider-color)',
+                borderRadius: '8px',
+                overflow: 'hidden',
+                backgroundColor: 'var(--secondary-background-color)',
+              }}>
+                {/* Highlighted pre behind textarea */}
+                <pre
+                  ref={preRef}
+                  aria-hidden
+                  data-testid="openvpn-preview-highlight"
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    margin: 0,
+                    padding: '12px',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    lineHeight: '1.5',
+                    whiteSpace: 'pre',
+                    overflow: 'hidden',
+                    pointerEvents: 'none',
+                    color: 'var(--primary-text-color)',
+                  }}
+                  dangerouslySetInnerHTML={{ __html: highlightOvpn(patchedContent, addedLines) }}
+                />
+
+                {/* Transparent editable textarea on top */}
+                <textarea
+                  value={patchedContent}
+                  onChange={(e) => setPatchedContent(e.target.value)}
+                  onScroll={handleScroll}
+                  spellCheck={false}
+                  style={{
+                    position: 'relative',
+                    width: '100%',
+                    minHeight: '300px',
+                    height: '100%',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    padding: '12px',
+                    border: 'none',
+                    backgroundColor: 'transparent',
+                    color: 'transparent',
+                    caretColor: 'var(--primary-text-color)',
+                    resize: 'vertical',
+                    lineHeight: '1.5',
+                    outline: 'none',
+                    whiteSpace: 'pre',
+                    overflow: 'auto',
+                  }}
+                  data-testid="openvpn-preview"
+                />
+              </div>
+
+              <HATextField
+                label="Download Filename"
+                value={downloadFilename}
+                onChange={(e) => setDownloadFilename(e.target.value)}
+                placeholder={`${instanceName}_patched.ovpn`}
+                data-testid="openvpn-download-filename"
               />
 
               <div style={{ display: 'flex', gap: '12px' }}>

--- a/squid_proxy_manager/frontend/src/features/instances/tabs/ConnectionInfoTab.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/tabs/ConnectionInfoTab.tsx
@@ -10,11 +10,9 @@ interface ConnectionInfoTabProps {
   instanceName: string;
   port: number;
   forwardAddress: string;
-  externalIp?: string;
-  externalPort?: number;
 }
 
-export function ConnectionInfoTab({ instanceName, port, forwardAddress, externalIp, externalPort }: ConnectionInfoTabProps) {
+export function ConnectionInfoTab({ instanceName, port, forwardAddress }: ConnectionInfoTabProps) {
   const [copied, setCopied] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
   const [showPatcherDialog, setShowPatcherDialog] = useState(false);
@@ -64,24 +62,6 @@ export function ConnectionInfoTab({ instanceName, port, forwardAddress, external
         <div style={{ padding: '12px', borderRadius: '8px', backgroundColor: 'var(--secondary-background-color, #282828)' }}>
           <div style={{ fontSize: '12px', color: 'var(--secondary-text-color)', marginBottom: '4px' }}>VPN Server</div>
           <div style={{ fontSize: '16px', fontWeight: 500, wordBreak: 'break-all' }}>{forwardAddress}</div>
-        </div>
-        <div
-          style={{ padding: '12px', borderRadius: '8px', backgroundColor: 'var(--secondary-background-color, #282828)' }}
-          data-testid="connection-info-external-address"
-        >
-          <div style={{ fontSize: '12px', color: 'var(--secondary-text-color)', marginBottom: '4px' }}>External Address</div>
-          <div style={{ fontSize: '16px', fontWeight: 500, wordBreak: 'break-all' }}>
-            {externalIp || <span style={{ color: 'var(--secondary-text-color)' }}>Not configured</span>}
-          </div>
-        </div>
-        <div
-          style={{ padding: '12px', borderRadius: '8px', backgroundColor: 'var(--secondary-background-color, #282828)' }}
-          data-testid="connection-info-external-port"
-        >
-          <div style={{ fontSize: '12px', color: 'var(--secondary-text-color)', marginBottom: '4px' }}>Client Port</div>
-          <div style={{ fontSize: '16px', fontWeight: 500 }}>
-            {externalPort ?? port}
-          </div>
         </div>
       </div>
 
@@ -166,7 +146,6 @@ export function ConnectionInfoTab({ instanceName, port, forwardAddress, external
         instanceName={instanceName}
         proxyType="tls_tunnel"
         port={port}
-        externalIp={externalIp}
       />
     </div>
   );

--- a/squid_proxy_manager/frontend/src/features/instances/tabs/GeneralTab.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/tabs/GeneralTab.tsx
@@ -15,12 +15,8 @@ interface GeneralTabProps {
   proxyType?: string;
   forwardAddress?: string;
   coverDomain?: string;
-  externalIp?: string;
-  externalPort?: number;
   onForwardAddressChange?: (addr: string) => void;
   onCoverDomainChange?: (domain: string) => void;
-  onExternalIpChange?: (ip: string) => void;
-  onExternalPortChange?: (port: number) => void;
 }
 
 export function GeneralTab({
@@ -32,16 +28,12 @@ export function GeneralTab({
   proxyType = 'squid',
   forwardAddress = '',
   coverDomain = '',
-  externalIp = '',
-  externalPort,
   onForwardAddressChange,
   onCoverDomainChange,
-  onExternalIpChange,
-  onExternalPortChange
 }: GeneralTabProps) {
   const queryClient = useQueryClient();
   const [saved, setSaved] = useState(false);
-  const [errors, setErrors] = useState<{ port?: string; forward_address?: string; cover_domain?: string; external_ip?: string; external_port?: string }>({});
+  const [errors, setErrors] = useState<{ port?: string; forward_address?: string; cover_domain?: string }>({});
 
   const updateMutation = useMutation({
     mutationFn: (payload: Record<string, unknown>) =>
@@ -67,23 +59,16 @@ export function GeneralTab({
   const textFieldsDirty =
     port !== instance.port ||
     (isTlsTunnel && forwardAddress !== (instance.forward_address ?? '')) ||
-    (isTlsTunnel && coverDomain !== (instance.cover_domain ?? '')) ||
-    externalIp !== (instance.external_ip ?? '') ||
-    (isTlsTunnel && externalPort !== (instance.external_port ?? port));
+    (isTlsTunnel && coverDomain !== (instance.cover_domain ?? ''));
 
   const handleSave = () => {
-    const payload: Record<string, unknown> = { port, external_ip: externalIp };
+    const payload: Record<string, unknown> = { port };
     if (isTlsTunnel) {
       payload.forward_address = forwardAddress;
       payload.cover_domain = coverDomain;
-      payload.external_port = externalPort ?? port;
     }
 
-    // Custom validation: external IP required for TLS tunnel
     const customErrors: typeof errors = {};
-    if (isTlsTunnel && !externalIp) {
-      customErrors.external_ip = 'External IP is required for TLS Tunnel instances';
-    }
 
     // Validate payload with schema
     const result = updateInstanceSchema.safeParse(payload);
@@ -132,41 +117,6 @@ export function GeneralTab({
         <p style={{ fontSize: '12px', color: 'var(--error-color, #db4437)', marginTop: '-8px' }}>
           {errors.port}
         </p>
-      )}
-
-      <HATextField
-        label="External IP / Hostname"
-        value={externalIp}
-        onChange={(e) => onExternalIpChange?.(e.target.value)}
-        placeholder="proxy.example.com or 192.168.1.100"
-        helperText={isTlsTunnel ? "External address clients use to connect (required for TLS tunnel)" : "External address for OpenVPN config patching (optional)"}
-        data-testid="settings-external-ip-input"
-      />
-      {errors.external_ip && (
-        <p style={{ fontSize: '12px', color: 'var(--error-color, #db4437)', marginTop: '-8px' }}>
-          {errors.external_ip}
-        </p>
-      )}
-
-      {isTlsTunnel && (
-        <>
-          <HATextField
-            label="External Port"
-            type="number"
-            value={String(externalPort ?? port)}
-            min={1024}
-            max={65535}
-            onChange={(e) => onExternalPortChange?.(Number(e.target.value))}
-            placeholder={String(port)}
-            helperText="Port clients use to connect (defaults to listen port if not set)"
-            data-testid="settings-external-port-input"
-          />
-          {errors.external_port && (
-            <p style={{ fontSize: '12px', color: 'var(--error-color, #db4437)', marginTop: '-8px' }}>
-              {errors.external_port}
-            </p>
-          )}
-        </>
       )}
 
       {!isTlsTunnel && (

--- a/squid_proxy_manager/frontend/src/features/instances/tabs/TestTab.tsx
+++ b/squid_proxy_manager/frontend/src/features/instances/tabs/TestTab.tsx
@@ -11,7 +11,6 @@ import { HAButton, HAIcon, HATextField } from '@/ui/ha-wrappers';
 interface TestTabProps {
   instanceName: string;
   port?: number;
-  externalIp?: string;
 }
 
 interface TestResult {
@@ -36,7 +35,7 @@ const testCredentialsSchema = z.object({
     })
 });
 
-export function TestTab({ instanceName, port = 3128, externalIp }: TestTabProps) {
+export function TestTab({ instanceName, port = 3128 }: TestTabProps) {
   const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -182,7 +181,6 @@ export function TestTab({ instanceName, port = 3128, externalIp }: TestTabProps)
         instanceName={instanceName}
         proxyType="squid"
         port={port}
-        externalIp={externalIp}
       />
     </div>
   );

--- a/squid_proxy_manager/rootfs/app/main.py
+++ b/squid_proxy_manager/rootfs/app/main.py
@@ -1073,9 +1073,15 @@ async def patch_ovpn_config(request):
         return web.json_response({"error": error_msg}, status=400)
 
     # Determine proxy host and port
-    proxy_host = external_host or instance.get("external_ip") or "localhost"
-    # For TLS tunnel, use external_port if set, otherwise fallback to listening port
-    proxy_port = instance.get("external_port") or instance["port"]
+    proxy_host = external_host or "localhost"
+    proxy_port = instance["port"]  # default to listen port
+
+    # Parse host:port from external_host (e.g. "proxy.example.com:4443")
+    if ":" in proxy_host:
+        host_part, port_part = proxy_host.rsplit(":", 1)
+        if port_part.isdigit():
+            proxy_host = host_part
+            proxy_port = int(port_part)
     proxy_type = instance.get("proxy_type", "squid")
 
     # Patch config based on proxy type

--- a/squid_proxy_manager/rootfs/app/ovpn_patcher.py
+++ b/squid_proxy_manager/rootfs/app/ovpn_patcher.py
@@ -94,47 +94,126 @@ def patch_ovpn_for_tls_tunnel(content: str, tunnel_host: str, tunnel_port: int) 
     """Patch .ovpn config to connect through TLS tunnel.
 
     Extracts VPN server address from original 'remote' directive and
-    replaces it with tunnel endpoint.
+    replaces it with tunnel endpoint. Also applies DPI evasion settings:
+    - Forces proto tcp (TLS tunnel requires TCP)
+    - Removes explicit-exit-notify (UDP-only, causes errors on TCP)
+    - Adds tun-mtu, mssfix, sndbuf/rcvbuf tuning
+    - Adds connect-retry-max and float for resilience
 
     Returns:
-        - patched_content: Config with remote replaced
+        - patched_content: Config with remote replaced and DPI settings applied
         - vpn_server: Extracted "host:port" from original remote directive
     """
     lines = content.split("\n")
     result = []
     vpn_server = None
     remote_replaced = False
+    proto_replaced = False
+
+    # Directives to remove (UDP-only or incompatible with TLS tunnel)
+    remove_directives = {"explicit-exit-notify"}
+
+    # Track which DPI settings already exist
+    existing_directives: set[str] = set()
+
+    # First pass: collect existing directive names
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith(";"):
+            directive = stripped.split()[0]
+            existing_directives.add(directive)
+
+    # Build DPI evasion block to insert near the top of the file
+    dpi_settings: list[str] = []
+    if "tun-mtu" not in existing_directives:
+        dpi_settings.append("tun-mtu 1500")
+    if "mssfix" not in existing_directives:
+        dpi_settings.append("mssfix 1300")
+    if "sndbuf" not in existing_directives:
+        dpi_settings.append("sndbuf 0")
+    if "rcvbuf" not in existing_directives:
+        dpi_settings.append("rcvbuf 0")
+    if "connect-retry-max" not in existing_directives:
+        dpi_settings.append("connect-retry-max 100")
+    if "float" not in existing_directives:
+        dpi_settings.append("float")
 
     for line in lines:
-        # Replace first 'remote' directive
-        if line.strip().startswith("remote") and not remote_replaced:
-            # Extract original VPN server address
-            parts = line.strip().split()
+        stripped = line.strip()
+
+        # Skip empty/comment lines — keep them as-is
+        if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+            result.append(line)
+            continue
+
+        directive = stripped.split()[0]
+
+        # Remove UDP-only directives
+        if directive in remove_directives:
+            result.append(f"# {line.rstrip()}  # removed for TLS tunnel (UDP-only)")
+            continue
+
+        # Replace first 'remote' directive and inject DPI settings right after
+        if directive == "remote" and not remote_replaced:
+            parts = stripped.split()
             if len(parts) >= 3:
                 vpn_host = parts[1]
                 vpn_port = parts[2]
                 vpn_server = f"{vpn_host}:{vpn_port}"
             elif len(parts) >= 2:
-                # If no port specified, assume 1194 (OpenVPN default)
                 vpn_host = parts[1]
                 vpn_server = f"{vpn_host}:1194"
 
-            # Replace with tunnel endpoint
             result.append(f"remote {tunnel_host} {tunnel_port}")
+            # Insert DPI evasion block right after the new remote directive
+            if dpi_settings:
+                result.append("")
+                result.append("# DPI evasion settings (added by TLS tunnel patcher)")
+                result.extend(dpi_settings)
+                result.append("")
             remote_replaced = True
-        else:
-            result.append(line)
+            continue
 
-    # If no remote directive found, add one
+        # Force proto tcp
+        if directive == "proto":
+            result.append("proto tcp")
+            proto_replaced = True
+            continue
+
+        result.append(line)
+
+    # If no remote directive found, add one with DPI settings
     if not remote_replaced:
-        # Insert after 'client' or at beginning
         inserted = False
         for i, line in enumerate(result):
             if line.strip().startswith("client"):
-                result.insert(i + 1, f"remote {tunnel_host} {tunnel_port}")
+                insert_pos = i + 1
+                result.insert(insert_pos, f"remote {tunnel_host} {tunnel_port}")
+                if dpi_settings:
+                    result.insert(insert_pos + 1, "")
+                    result.insert(
+                        insert_pos + 2, "# DPI evasion settings (added by TLS tunnel patcher)"
+                    )
+                    for j, setting in enumerate(dpi_settings):
+                        result.insert(insert_pos + 3 + j, setting)
+                    result.insert(insert_pos + 3 + len(dpi_settings), "")
                 inserted = True
                 break
         if not inserted:
             result.insert(0, f"remote {tunnel_host} {tunnel_port}")
+            if dpi_settings:
+                result.insert(1, "")
+                result.insert(2, "# DPI evasion settings (added by TLS tunnel patcher)")
+                for j, setting in enumerate(dpi_settings):
+                    result.insert(3 + j, setting)
+                result.insert(3 + len(dpi_settings), "")
+
+    # Add proto tcp if it wasn't already in the file and wasn't replaced
+    if not proto_replaced and "proto" not in existing_directives:
+        # Insert after the DPI block (find the comment marker)
+        for i, line in enumerate(result):
+            if line.strip() == "# DPI evasion settings (added by TLS tunnel patcher)":
+                result.insert(i, "proto tcp")
+                break
 
     return "\n".join(result), vpn_server or ""

--- a/tests/e2e/test_1_6_8_features.py
+++ b/tests/e2e/test_1_6_8_features.py
@@ -1,16 +1,16 @@
-"""E2E tests for 1.6.8 stabilization release features.
+"""E2E tests for 1.6.8+ features (updated for v1.6.9 changes).
 
-Tests carried forward from 1.6.7:
-1. External port field for TLS tunnel
-2. External IP validation for TLS tunnel (required)
-3. VPN server extraction from .ovpn upload
-4. Raw config editor with line numbers
-5. Click-to-browse file upload
+Active tests:
+1. VPN server extraction from .ovpn upload (external address now in dialog)
+2. Raw config editor with line numbers
+3. Click-to-browse file upload (external address now in dialog)
+4. OpenVPN patch blocked without external address (TLS tunnel)
+5. Raw config syntax highlighting
 
-New tests for 1.6.8:
-6. External address shown in connection info
-7. OpenVPN patch blocked without external IP (TLS tunnel)
-8. Raw config syntax highlighting
+Removed in v1.6.9 (external IP/port moved from settings to dialog):
+- External port field for TLS tunnel (settings field removed)
+- External IP validation for TLS tunnel (validation now in dialog)
+- External address shown in connection info (grid cells removed)
 
 All tests use per-test fixtures for parallel execution.
 """
@@ -30,144 +30,6 @@ from tests.e2e.utils import (
 ADDON_URL = os.getenv("ADDON_URL", "http://localhost:8099")
 SUPERVISOR_TOKEN = os.getenv("SUPERVISOR_TOKEN", "dev_token")
 API_HEADERS = {"Authorization": f"Bearer {SUPERVISOR_TOKEN}"}
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_external_port_field_tls_tunnel(browser, unique_name, unique_port, api_session):
-    """Test external port field for TLS tunnel instances.
-
-    Verifies:
-    - External port field is visible for TLS tunnel in settings
-    - External port can be set to a different value than listen port
-    - External port defaults to listen port if not set
-    - API correctly returns external_port value
-    """
-    instance_name = unique_name("external-port")
-    listen_port = unique_port(8500)
-    external_port = unique_port(8501)
-
-    page = await browser.new_page()
-    try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
-            instance_name,
-            listen_port,
-            forward_address="vpn.example.com:1194",
-        )
-
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-
-        # Navigate to settings
-        await navigate_to_settings(page, instance_name)
-
-        # Verify external port field is visible
-        external_port_input = page.locator('[data-testid="settings-external-port-input"]')
-        await external_port_input.wait_for(state="visible", timeout=10000)
-
-        # Set external IP (required for TLS tunnel)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-
-        # Set external port to different value
-        await fill_textfield_by_testid(page, "settings-external-port-input", str(external_port))
-        await asyncio.sleep(0.5)
-
-        # Save changes
-        await page.wait_for_selector(
-            '[data-testid="settings-save-button"]:not([disabled])', timeout=5000
-        )
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-
-        await asyncio.sleep(2)
-
-        # Verify via API
-        async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
-            data = await resp.json()
-            instance = next((i for i in data["instances"] if i["name"] == instance_name), None)
-            assert instance is not None
-            assert (
-                instance.get("external_port") == external_port
-            ), f"external_port should be {external_port}, got: {instance.get('external_port')}"
-            assert instance.get("external_ip") == "tunnel.example.com"
-    finally:
-        await page.close()
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_external_ip_required_validation(browser, unique_name, unique_port, api_session):
-    """Test that external IP is required for TLS tunnel.
-
-    Verifies:
-    - Save button works when external IP is set
-    - Validation error appears when trying to save without external IP
-    - Error message is clear and actionable
-    """
-    instance_name = unique_name("ext-ip-validation")
-    port = unique_port(8502)
-
-    page = await browser.new_page()
-    try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance with external IP
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
-            instance_name,
-            port,
-            forward_address="vpn.example.com:1194",
-        )
-
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-
-        # Navigate to settings
-        await navigate_to_settings(page, instance_name)
-
-        # Set external IP first (so we can test clearing it)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-        await asyncio.sleep(0.5)
-
-        # Save should work with external IP
-        await page.wait_for_selector(
-            '[data-testid="settings-save-button"]:not([disabled])', timeout=5000
-        )
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-
-        # Wait for "Saved!" to disappear before second save attempt
-        # (GeneralTab shows "Saved!" for 2 seconds then reverts to "Save Changes")
-        await page.locator("text=Saved!").wait_for(state="hidden", timeout=5000)
-        await asyncio.sleep(0.5)
-
-        # Now clear external IP
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "")
-        # Make another change to make form dirty
-        await fill_textfield_by_testid(page, "settings-cover-domain-input", "new.example.com")
-        await asyncio.sleep(0.5)
-
-        # Try to save - should fail validation
-        await page.wait_for_selector(
-            '[data-testid="settings-save-button"]:not([disabled])', timeout=5000
-        )
-        await page.click('[data-testid="settings-save-button"]')
-
-        # Validation error should appear
-        error_msg = await page.wait_for_selector("text=/External IP is required/", timeout=5000)
-        assert error_msg is not None, "Validation error should be displayed"
-
-        # "Saved!" should NOT appear since validation failed
-        saved_text = page.locator("text=Saved!")
-        assert (
-            await saved_text.count() == 0
-        ), "Saved message should not appear when validation fails"
-    finally:
-        await page.close()
 
 
 @pytest.mark.e2e
@@ -200,15 +62,8 @@ async def test_vpn_server_extraction_from_ovpn(browser, unique_name, unique_port
 
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Navigate to settings and set external IP
+        # Navigate to settings
         await navigate_to_settings(page, instance_name)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-        await asyncio.sleep(0.5)
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-        # Wait for save to complete and UI to settle
-        await page.locator("text=Saved!").wait_for(state="hidden", timeout=5000)
-        await asyncio.sleep(1)
 
         # Scroll to Connection Info card and find OpenVPN patcher button
         patcher_button = page.locator('[data-testid="connection-info-openvpn-button"]')
@@ -219,6 +74,10 @@ async def test_vpn_server_extraction_from_ovpn(browser, unique_name, unique_port
         # Dialog should open
         dialog = page.locator('[data-testid="openvpn-dialog"]')
         await dialog.wait_for(state="visible", timeout=10000)
+
+        # Fill external address in dialog (moved from settings in v1.6.9)
+        await fill_textfield_by_testid(page, "openvpn-external-address-input", "tunnel.example.com")
+        await asyncio.sleep(0.5)
 
         # Create a mock .ovpn file with a different VPN server
         ovpn_content = """client
@@ -394,15 +253,8 @@ async def test_click_to_browse_file_upload(browser, unique_name, unique_port, ap
 
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Navigate to settings and set external IP
+        # Navigate to settings
         await navigate_to_settings(page, instance_name)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-        await asyncio.sleep(0.5)
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-        # Wait for save to complete and UI to settle
-        await page.locator("text=Saved!").wait_for(state="hidden", timeout=5000)
-        await asyncio.sleep(1)
 
         # Scroll to Connection Info card and open OpenVPN patcher dialog
         patcher_button = page.locator('[data-testid="connection-info-openvpn-button"]')
@@ -413,6 +265,10 @@ async def test_click_to_browse_file_upload(browser, unique_name, unique_port, ap
         # Dialog should open
         dialog = page.locator('[data-testid="openvpn-dialog"]')
         await dialog.wait_for(state="visible", timeout=10000)
+
+        # Fill external address in dialog (moved from settings in v1.6.9)
+        await fill_textfield_by_testid(page, "openvpn-external-address-input", "tunnel.example.com")
+        await asyncio.sleep(0.5)
 
         # Find the drag-drop zone by data-testid
         drop_zone = page.locator('[data-testid="openvpn-drop-zone"]')
@@ -446,87 +302,6 @@ remote vpn.server.com 1194
         # Verify file name is displayed
         page_text = await page.inner_text("body")
         assert "clicked.ovpn" in page_text, "Selected file name should be displayed"
-    finally:
-        await page.close()
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_external_address_shown_in_connection_info(
-    browser, unique_name, unique_port, api_session
-):
-    """Test external address is displayed in connection info.
-
-    Verifies:
-    - "Not configured" shown when external IP is not set
-    - External address and client port shown after saving settings
-    """
-    instance_name = unique_name("conn-info-addr")
-    listen_port = unique_port(8506)
-    external_port = unique_port(8507)
-
-    page = await browser.new_page()
-    try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
-            instance_name,
-            listen_port,
-            forward_address="vpn.example.com:1194",
-        )
-
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-
-        # Navigate to settings
-        await navigate_to_settings(page, instance_name)
-
-        # Scroll to Connection Info section
-        ext_addr = page.locator('[data-testid="connection-info-external-address"]')
-        await ext_addr.scroll_into_view_if_needed()
-        await ext_addr.wait_for(state="visible", timeout=10000)
-
-        # Should show "Not configured" initially
-        ext_addr_text = await ext_addr.inner_text()
-        assert (
-            "Not configured" in ext_addr_text
-        ), f"Should show 'Not configured' initially, got: {ext_addr_text}"
-
-        # Client port should default to listen port
-        ext_port_el = page.locator('[data-testid="connection-info-external-port"]')
-        ext_port_text = await ext_port_el.inner_text()
-        assert (
-            str(listen_port) in ext_port_text
-        ), f"Client port should default to listen port {listen_port}, got: {ext_port_text}"
-
-        # Now set external IP and external port
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "my.tunnel.com")
-        await fill_textfield_by_testid(page, "settings-external-port-input", str(external_port))
-        await asyncio.sleep(0.5)
-
-        await page.wait_for_selector(
-            '[data-testid="settings-save-button"]:not([disabled])', timeout=5000
-        )
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-        await asyncio.sleep(2)
-
-        # Scroll back to connection info
-        await ext_addr.scroll_into_view_if_needed()
-
-        # External address should now show the IP
-        ext_addr_text = await ext_addr.inner_text()
-        assert (
-            "my.tunnel.com" in ext_addr_text
-        ), f"Should show external IP after save, got: {ext_addr_text}"
-
-        # Client port should show external port
-        ext_port_text = await ext_port_el.inner_text()
-        assert (
-            str(external_port) in ext_port_text
-        ), f"Client port should show {external_port} after save, got: {ext_port_text}"
     finally:
         await page.close()
 
@@ -578,8 +353,8 @@ async def test_openvpn_patch_blocked_without_external_ip(
         await error_card.wait_for(state="visible", timeout=5000)
         error_text = await error_card.inner_text()
         assert (
-            "External IP is required" in error_text
-        ), f"Error message should mention external IP is required, got: {error_text}"
+            "External address is required" in error_text
+        ), f"Error message should mention external address is required, got: {error_text}"
 
         # Upload a file
         ovpn_content = """client
@@ -597,10 +372,12 @@ remote vpn.server.com 1194
         )
         await asyncio.sleep(1)
 
-        # Patch button should be disabled (file uploaded but no external IP)
+        # Patch button should be disabled (file uploaded but no external address)
         patch_button = page.locator('[data-testid="openvpn-patch-button"]')
         is_disabled = await patch_button.is_disabled()
-        assert is_disabled, "Patch button should be disabled without external IP for TLS tunnel"
+        assert (
+            is_disabled
+        ), "Patch button should be disabled without external address for TLS tunnel"
     finally:
         await page.close()
 

--- a/tests/e2e/test_ovpn_patcher_e2e.py
+++ b/tests/e2e/test_ovpn_patcher_e2e.py
@@ -162,7 +162,10 @@ async def test_upload_and_patch_ovpn_squid(browser, unique_name, unique_port, ap
         assert "client" in preview_content, "Original 'client' directive should be preserved"
         assert "dev tun" in preview_content, "Original 'dev tun' directive should be preserved"
 
-        # Step 8: Verify download button is enabled in dialog
+        # Step 8: Verify download filename field and download button
+        filename_input = await page.query_selector('[data-testid="openvpn-download-filename"]')
+        assert filename_input, "Download filename input should appear after patch"
+
         download_button = await page.query_selector('[data-testid="openvpn-download"]')
         assert download_button, "Download button should appear after successful patch"
 
@@ -172,6 +175,10 @@ async def test_upload_and_patch_ovpn_squid(browser, unique_name, unique_port, ap
         # Verify copy button is also enabled
         copy_button = await page.query_selector('[data-testid="openvpn-copy"]')
         assert copy_button, "Copy button should appear after successful patch"
+
+        # Verify syntax highlighting overlay exists
+        highlight_pre = await page.query_selector('[data-testid="openvpn-preview-highlight"]')
+        assert highlight_pre, "Syntax highlighting pre overlay should exist"
 
         # Close dialog
         close_button = await page.query_selector('[data-testid="openvpn-dialog-close"]')
@@ -196,10 +203,11 @@ async def test_upload_and_patch_ovpn_tls_tunnel(browser, unique_name, unique_por
     2. Navigate to instance settings
     3. Navigate to Connection Info tab
     4. Click "Patch OpenVPN Config" button to open dialog
-    5. Upload .ovpn file with remote directive in dialog
-    6. Click patch button in dialog
-    7. Verify patched content has tunnel endpoint in dialog
-    8. Verify instance forward_address updated
+    5. Fill external address in dialog
+    6. Upload .ovpn file with remote directive in dialog
+    7. Click patch button in dialog
+    8. Verify patched content has tunnel endpoint and DPI settings
+    9. Verify instance forward_address updated
     """
     instance_name = unique_name("ovpn-tls")
     port = unique_port(4500)
@@ -224,17 +232,6 @@ async def test_upload_and_patch_ovpn_tls_tunnel(browser, unique_name, unique_por
         # Step 2: Navigate to instance settings
         await navigate_to_settings(page, instance_name)
 
-        # Set external IP (required for TLS tunnel patching)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-        await asyncio.sleep(0.5)
-        await page.wait_for_selector(
-            '[data-testid="settings-save-button"]:not([disabled])', timeout=5000
-        )
-        await page.click('[data-testid="settings-save-button"]')
-        await page.wait_for_selector("text=Saved!", timeout=10000)
-        await page.locator("text=Saved!").wait_for(state="hidden", timeout=5000)
-        await asyncio.sleep(1)
-
         # Step 3: Click "Patch OpenVPN Config" button (in Connection Info card)
         patcher_button = page.locator('[data-testid="connection-info-openvpn-button"]')
         await patcher_button.scroll_into_view_if_needed()
@@ -243,6 +240,10 @@ async def test_upload_and_patch_ovpn_tls_tunnel(browser, unique_name, unique_por
 
         # Wait for dialog to appear
         await page.wait_for_selector('[data-testid="openvpn-dialog"]', timeout=5000)
+
+        # Step 4: Fill external address in the dialog (required for TLS tunnel)
+        await fill_textfield_by_testid(page, "openvpn-external-address-input", "tunnel.example.com")
+        await asyncio.sleep(0.5)
 
         # Step 5: Upload .ovpn file with remote directive in dialog
         ovpn_file_path = FIXTURES_DIR / "tls_tunnel_config.ovpn"
@@ -276,16 +277,39 @@ async def test_upload_and_patch_ovpn_tls_tunnel(browser, unique_name, unique_por
 
         # Verify remote directive was replaced with tunnel endpoint
         assert (
-            "remote tunnel.example.com" in preview_content
-            or "remote localhost" in preview_content
-            or "remote 127.0.0.1" in preview_content
-        ), "Patched content should have tunnel endpoint as remote"
-        assert str(port) in preview_content, f"Patched content should contain tunnel port {port}"
+            f"remote tunnel.example.com {port}" in preview_content
+        ), f"Patched content should have 'remote tunnel.example.com {port}'"
 
         # Original VPN server should NOT be in the patched config
         assert (
             "vpn-server.example.org" not in preview_content
         ), "Original VPN server should be replaced"
+
+        # Verify DPI evasion settings are present
+        assert "proto tcp" in preview_content, "DPI: proto tcp should be present"
+        assert "tun-mtu 1500" in preview_content, "DPI: tun-mtu should be present"
+        assert "mssfix 1300" in preview_content, "DPI: mssfix should be present"
+        assert "sndbuf 0" in preview_content, "DPI: sndbuf should be present"
+        assert "rcvbuf 0" in preview_content, "DPI: rcvbuf should be present"
+        assert (
+            "connect-retry-max 100" in preview_content
+        ), "DPI: connect-retry-max should be present"
+        assert "float" in preview_content, "DPI: float should be present"
+
+        # Verify DPI settings appear near the top (after remote, before verb)
+        remote_idx = preview_content.index(f"remote tunnel.example.com {port}")
+        dpi_comment_idx = preview_content.index("# DPI evasion settings")
+        assert (
+            dpi_comment_idx > remote_idx
+        ), "DPI settings should appear right after remote directive"
+
+        # Verify syntax highlighting overlay exists (embedded diff)
+        highlight_pre = await page.query_selector('[data-testid="openvpn-preview-highlight"]')
+        assert highlight_pre, "Syntax highlighting overlay should exist for diff display"
+
+        # Verify download filename field exists
+        filename_input = await page.query_selector('[data-testid="openvpn-download-filename"]')
+        assert filename_input, "Download filename field should be present"
 
         # Step 8: Verify instance forward_address updated via API
         async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
@@ -392,6 +416,148 @@ async def test_ovpn_with_auth_credentials(browser, unique_name, unique_port, api
         ), "Patched content should contain auth block end"
         assert "testuser" in preview_content, "Patched content should contain username"
         assert "testpass" in preview_content, "Patched content should contain password"
+
+    finally:
+        await page.close()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_ovpn_external_address_in_dialog(browser, unique_name, unique_port, api_session):
+    """E2E test: External address is provided in the dialog, not in settings.
+
+    Verifies:
+    1. External address input exists in the patcher dialog
+    2. For TLS tunnel, patch button is disabled without external address
+    3. Filling external address enables the patch button
+    4. External address is used in the patched config
+    """
+    instance_name = unique_name("ovpn-addr")
+    port = unique_port(4600)
+
+    page = await browser.new_page()
+    try:
+        await page.goto(ADDON_URL)
+
+        # Create TLS Tunnel instance
+        await create_tls_tunnel_via_ui(
+            page,
+            ADDON_URL,
+            instance_name,
+            port,
+            forward_address="192.168.1.1:1194",
+            timeout=60000,
+        )
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+
+        # Navigate to settings and open patcher dialog
+        await navigate_to_settings(page, instance_name)
+        patcher_button = page.locator('[data-testid="connection-info-openvpn-button"]')
+        await patcher_button.scroll_into_view_if_needed()
+        await patcher_button.wait_for(state="visible", timeout=10000)
+        await patcher_button.click()
+        await page.wait_for_selector('[data-testid="openvpn-dialog"]', timeout=5000)
+
+        # Verify external address input exists in dialog
+        ext_input = await page.query_selector('[data-testid="openvpn-external-address-input"]')
+        assert ext_input, "External address input should exist in the dialog"
+
+        # Verify error card shows when external address is empty (TLS tunnel)
+        error_card = await page.query_selector('[data-testid="openvpn-external-ip-error"]')
+        assert error_card, "Error card should show when external address is empty for TLS tunnel"
+
+        # Upload file first
+        ovpn_file_path = FIXTURES_DIR / "tls_tunnel_config.ovpn"
+        file_input = await page.query_selector('[data-testid="openvpn-file-input"]')
+        await file_input.set_input_files(str(ovpn_file_path))
+        await page.wait_for_selector("text=/tls_tunnel_config.ovpn/", timeout=10000)
+
+        # Verify patch button is DISABLED without external address
+        patch_button = await page.query_selector('[data-testid="openvpn-patch-button"]')
+        is_disabled = await patch_button.get_attribute("disabled")
+        assert is_disabled is not None, "Patch button should be disabled without external address"
+
+        # Fill external address with port
+        await fill_textfield_by_testid(page, "openvpn-external-address-input", "myserver.com:4443")
+        await asyncio.sleep(0.5)
+
+        # Verify error card disappears
+        error_card = await page.query_selector('[data-testid="openvpn-external-ip-error"]')
+        assert error_card is None, "Error card should disappear after filling external address"
+
+        # Verify patch button is now enabled
+        patch_button = await page.query_selector('[data-testid="openvpn-patch-button"]')
+        is_disabled = await patch_button.get_attribute("disabled")
+        assert is_disabled is None, "Patch button should be enabled after filling external address"
+
+        # Patch and verify the external address is used (with port parsing)
+        await patch_button.click()
+        await page.wait_for_selector('[data-testid="openvpn-preview"]', timeout=15000)
+
+        preview = await page.query_selector('[data-testid="openvpn-preview"]')
+        preview_content = await preview.input_value()
+        assert (
+            "remote myserver.com 4443" in preview_content
+        ), "Patched config should use external address with parsed port"
+
+    finally:
+        await page.close()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_ovpn_download_filename(browser, unique_name, unique_port, api_session):
+    """E2E test: Download filename can be customized.
+
+    Verifies:
+    1. Download filename field exists after patching
+    2. Default filename is {instanceName}_patched.ovpn
+    3. Filename field is editable
+    """
+    instance_name = unique_name("ovpn-fname")
+    port = unique_port(3600)
+
+    page = await browser.new_page()
+    try:
+        await page.goto(ADDON_URL)
+
+        # Create Squid instance
+        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+
+        # Navigate to settings and open patcher dialog
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
+        await navigate_to_settings(page, instance_name)
+        await page.wait_for_selector(
+            '[data-testid="test-connectivity-openvpn-button"]', timeout=10000
+        )
+        await page.click('[data-testid="test-connectivity-openvpn-button"]')
+        await page.wait_for_selector('[data-testid="openvpn-dialog"]', timeout=5000)
+
+        # Upload and patch
+        ovpn_file_path = FIXTURES_DIR / "basic_client.ovpn"
+        file_input = await page.query_selector('[data-testid="openvpn-file-input"]')
+        await file_input.set_input_files(str(ovpn_file_path))
+        await page.wait_for_selector("text=/basic_client.ovpn/", timeout=10000)
+        await page.click('[data-testid="openvpn-patch-button"]')
+        await page.wait_for_selector('[data-testid="openvpn-preview"]', timeout=15000)
+
+        # Verify filename input exists with default value
+        filename_input = page.locator('[data-testid="openvpn-download-filename"] input')
+        await filename_input.wait_for(state="visible", timeout=5000)
+        default_value = await filename_input.input_value()
+        assert (
+            default_value == f"{instance_name}_patched.ovpn"
+        ), f"Default filename should be '{instance_name}_patched.ovpn', got '{default_value}'"
+
+        # Verify filename is editable
+        await filename_input.fill("my_custom_config.ovpn")
+        await asyncio.sleep(0.3)
+        new_value = await filename_input.input_value()
+        assert new_value == "my_custom_config.ovpn", "Filename should be editable"
 
     finally:
         await page.close()

--- a/tests/e2e/test_tls_tunnel.py
+++ b/tests/e2e/test_tls_tunnel.py
@@ -379,9 +379,6 @@ async def test_update_tls_tunnel_settings(browser, unique_name, unique_port, api
 
         await navigate_to_settings(page, instance_name)
 
-        # Set external IP (required for TLS tunnel)
-        await fill_textfield_by_testid(page, "settings-external-ip-input", "tunnel.example.com")
-
         # Update the forward address field in GeneralTab
         await fill_textfield_by_testid(page, "settings-forward-address-input", "vpn.new.com:443")
 

--- a/tests/integration/test_ovpn_patching_api.py
+++ b/tests/integration/test_ovpn_patching_api.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aiohttp import FormData
 from aiohttp.test_utils import make_mocked_request
 
 # Add parent directory to path for imports
@@ -40,13 +39,11 @@ def mock_manager():
                 "name": "squid-proxy",
                 "port": 3128,
                 "proxy_type": "squid",
-                "external_ip": "192.168.1.100",
             },
             {
                 "name": "tls-tunnel",
                 "port": 4443,
                 "proxy_type": "tls_tunnel",
-                "external_ip": "10.0.0.50",
             },
         ]
     )
@@ -77,12 +74,6 @@ class TestPatchOVPNSquidInstance:
 
         importlib.reload(main)
 
-        # Create multipart form data
-        form = FormData()
-        form.add_field(
-            "file", basic_ovpn_content, filename="client.ovpn", content_type="text/plain"
-        )
-
         # Create mock request with multipart reader
         request = make_mocked_request(
             "POST",
@@ -91,21 +82,22 @@ class TestPatchOVPNSquidInstance:
             match_info={"name": "squid-proxy"},
         )
 
-        # Mock multipart reader
+        # Mock multipart reader — external_host is now sent from the dialog
         async def mock_multipart_gen():
-            """Mock multipart reader that yields file content."""
-            parts = []
-
             class FilePart:
                 name = "file"
 
                 async def read(self):
                     return basic_ovpn_content.encode("utf-8")
 
-            parts.append(FilePart())
+            class ExternalHostPart:
+                name = "external_host"
 
-            for part in parts:
-                yield part
+                async def text(self):
+                    return "192.168.1.100"
+
+            yield FilePart()
+            yield ExternalHostPart()
 
         async def mock_multipart():
             return mock_multipart_gen()
@@ -143,13 +135,19 @@ class TestPatchOVPNSquidInstance:
             match_info={"name": "squid-proxy"},
         )
 
-        # Mock multipart reader with auth credentials
+        # Mock multipart reader with auth credentials + external_host
         async def mock_multipart_gen():
             class FilePart:
                 name = "file"
 
                 async def read(self):
                     return basic_ovpn_content.encode("utf-8")
+
+            class ExternalHostPart:
+                name = "external_host"
+
+                async def text(self):
+                    return "192.168.1.100"
 
             class UsernamePart:
                 name = "username"
@@ -164,6 +162,7 @@ class TestPatchOVPNSquidInstance:
                     return "testpass"
 
             yield FilePart()
+            yield ExternalHostPart()
             yield UsernamePart()
             yield PasswordPart()
 
@@ -253,6 +252,7 @@ class TestPatchOVPNTLSTunnelInstance:
             match_info={"name": "tls-tunnel"},
         )
 
+        # external_host is now sent from the dialog
         async def mock_multipart_gen():
             class FilePart:
                 name = "file"
@@ -260,7 +260,14 @@ class TestPatchOVPNTLSTunnelInstance:
                 async def read(self):
                     return tls_tunnel_ovpn_content.encode("utf-8")
 
+            class ExternalHostPart:
+                name = "external_host"
+
+                async def text(self):
+                    return "10.0.0.50"
+
             yield FilePart()
+            yield ExternalHostPart()
 
         async def mock_multipart():
             return mock_multipart_gen()


### PR DESCRIPTION
## Summary
- **External Address** moved from instance settings to OpenVPN Patcher dialog where it's actually used
- **Port duplication bug** fixed: `rbnkv.com:4443` no longer produces `remote rbnkv.com:4443 8443`
- **Editable patched config preview** with OpenVPN syntax highlighting (keywords, comments, numbers, strings)
- **Embedded diff highlighting**: green for added lines, red strikethrough for removed directives
- **Customizable download filename** (defaults to `{instance}_patched.ovpn`)
- **DPI evasion settings** automatically added to TLS tunnel patches (`proto tcp`, `tun-mtu`, `mssfix`, `sndbuf/rcvbuf`, `connect-retry-max`, `float`)
- DPI settings injected right after `remote` directive for better visibility
- External address input shows error (TLS tunnel) or warning (Squid) when empty

## Files changed (15 files, +905/-200)
| File | Change |
|------|--------|
| `OpenVPNPatcherDialog.tsx` | Add external address input, editable highlighted preview with diff, download filename field |
| `GeneralTab.tsx` | Remove external IP + external port fields (moved to dialog) |
| `InstanceSettingsPage.tsx` | Remove externalIp/externalPort state and prop passing |
| `ConnectionInfoTab.tsx` | Remove externalIp/externalPort props and grid cells |
| `TestTab.tsx` | Remove externalIp prop |
| `main.py` | Parse host:port from external_host, drop external_ip/external_port fallbacks |
| `ovpn_patcher.py` | Add DPI evasion settings, inject after remote directive |
| `test_ovpn_patching_api.py` | Send external_host via form data (match new dialog flow) |
| `test_ovpn_patcher_e2e.py` | Update E2E tests + add 2 new tests for dialog address & filename |
| `OpenVPNPatcherDialog.test.tsx` | Update unit tests for removed prop + new inputs |
| `record_workflows_impl.py` | Add workflow 4: OpenVPN patcher GIF recording |
| `config.yaml` / `Dockerfile` / `package.json` | Version bump 1.6.8 → 1.6.9 |
| `CHANGELOG.md` | Add v1.6.9 release notes |

## Test plan
- [x] Frontend unit tests: 83/83 passed
- [x] Backend unit + integration tests: 257 passed, 0 failed
- [x] TypeScript typecheck: clean
- [x] Lint: clean (auto-formatted)
- [x] E2E browser tests (run via `./run_tests.sh e2e`)
- [x] Manual test: upload .ovpn with host:port external address — verify no port duplication
- [x] Manual test: edit patched config in preview — download reflects edits
- [x] Manual test: verify diff highlighting shows green for added DPI settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)