### PR TITLE
v1.6.10: E2E perf, external address dialog, OpenVPN patcher improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ HA Squid Proxy Manager is a **Home Assistant Add-on** (not a custom component) t
 
 # Run specific test suites
 ./run_tests.sh unit     # Unit + integration (~60s)
-./run_tests.sh e2e      # E2E browser tests (~180s)
+./run_tests.sh e2e      # E2E browser tests (~240s)
 
 # Run single test
 pytest tests/unit/test_proxy_manager.py::test_create_instance -v

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -69,8 +69,8 @@ services:
       - .:/repo
       - ./test-results:/repo/test-results
     working_dir: /repo
-    mem_limit: 3g
-    mem_reservation: 1g
+    mem_limit: 4g
+    mem_reservation: 2g
     profiles:
       - e2e
       - all
@@ -78,7 +78,7 @@ services:
       [
         "sh",
         "-c",
-        "cd /repo && pytest tests/e2e -v --tb=short -n ${E2E_WORKERS:-1} --dist=loadscope --screenshot=only-on-failure --video=retain-on-failure --tracing=retain-on-failure --output=test-results",
+        "cd /repo && pytest tests/e2e -v --tb=short -n ${E2E_WORKERS:-3} --dist=loadscope --screenshot=only-on-failure --video=retain-on-failure --tracing=retain-on-failure --output=test-results",
       ]
 
   # Lint runner (pre-commit) for CI consistency

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -46,7 +46,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 10s
+      start_period: 5s
     mem_limit: 2g
     mem_reservation: 512m
     profiles:
@@ -78,7 +78,7 @@ services:
       [
         "sh",
         "-c",
-        "cd /repo && pytest tests/e2e -v --tb=short -n ${E2E_WORKERS:-3} --dist=loadscope --screenshot=only-on-failure --video=retain-on-failure --tracing=retain-on-failure --output=test-results",
+        "cd /repo && pytest tests/e2e -v --tb=short -n ${E2E_WORKERS:-4} --dist=load --durations=20 --screenshot=only-on-failure --video=retain-on-failure --tracing=retain-on-failure --output=test-results",
       ]
 
   # Lint runner (pre-commit) for CI consistency

--- a/squid_proxy_manager/Dockerfile
+++ b/squid_proxy_manager/Dockerfile
@@ -22,7 +22,7 @@ LABEL \
     io.hass.name="Squid Proxy Manager" \
     io.hass.description="Manage multiple Squid proxy instances" \
     io.hass.type="addon" \
-    io.hass.version="1.6.9"
+    io.hass.version="1.6.10"
 
 # Set working directory
 WORKDIR /app

--- a/squid_proxy_manager/config.yaml
+++ b/squid_proxy_manager/config.yaml
@@ -1,6 +1,6 @@
 name: Squid Proxy Manager
 description: Manage multiple Squid proxy instances with HTTPS support and basic authentication
-version: "1.6.9"
+version: "1.6.10"
 slug: squid_proxy_manager
 url: "https://github.com/rybnikov/HA_SQUID_PROXY"
 init: false

--- a/squid_proxy_manager/frontend/package.json
+++ b/squid_proxy_manager/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-proxy-manager-ui",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -27,8 +27,10 @@ RUN set -eux; \
 
 # Install Python dependencies from pinned requirements file
 COPY tests/requirements-test.txt tests/requirements-test.txt
-RUN pip install --no-cache-dir -r tests/requirements-test.txt \
-    && playwright install chromium
+RUN pip install --no-cache-dir -r tests/requirements-test.txt
+
+# Cache Playwright browser in separate layer (survives pip requirement changes)
+RUN playwright install chromium
 
 # Copy test files for standalone use (overridden by volume mount in docker-compose)
 COPY tests/e2e/ ./tests/e2e/

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -104,15 +104,12 @@ async def cleanup_addon_data_before_tests():
                         break
         except Exception:
             pass
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.5)
 
-    await asyncio.sleep(1)  # Extra buffer after health check passes
-
-    # Clean all addon data via API — retry until zero instances remain
+    # Clean all addon data via API — skip if already empty
     try:
         async with aiohttp.ClientSession(headers=API_HEADERS) as session:
             for _round in range(3):
-                # Get list of all instances
                 async with session.get(
                     f"{ADDON_URL}/api/instances", timeout=aiohttp.ClientTimeout(total=5)
                 ) as resp:
@@ -121,23 +118,26 @@ async def cleanup_addon_data_before_tests():
                         instances = data.get("instances", []) if isinstance(data, dict) else data
                         if not instances:
                             break
-                        # Delete each instance sequentially to avoid race conditions
+                        # Delete all instances concurrently
+                        delete_tasks = []
                         for instance in instances:
                             instance_name = instance.get("name")
                             if instance_name:
-                                try:
-                                    async with session.delete(
+                                delete_tasks.append(
+                                    session.delete(
                                         f"{ADDON_URL}/api/instances/{instance_name}",
                                         timeout=aiohttp.ClientTimeout(total=20),
-                                    ) as del_resp:
-                                        _ = del_resp.status
-                                        await asyncio.sleep(1)
-                                except Exception:
-                                    pass
-                # Wait for processes to fully terminate before verifying
-                await asyncio.sleep(3)
+                                    )
+                                )
+                        for task in delete_tasks:
+                            try:
+                                async with task as del_resp:
+                                    _ = del_resp.status
+                            except Exception:
+                                pass
+                await asyncio.sleep(1)
 
-            # Verify all instances are gone
+            # Verify all instances are gone (fast polling)
             for _ in range(10):
                 async with session.get(
                     f"{ADDON_URL}/api/instances", timeout=aiohttp.ClientTimeout(total=5)
@@ -147,12 +147,9 @@ async def cleanup_addon_data_before_tests():
                         remaining = data.get("instances", []) if isinstance(data, dict) else data
                         if not remaining:
                             break
-                await asyncio.sleep(2)
+                await asyncio.sleep(0.5)
     except Exception:
         pass  # If API cleanup fails, continue anyway
-
-    # Final wait to ensure cleanup settles
-    await asyncio.sleep(1)
 
 
 @pytest.fixture(scope="session")
@@ -249,7 +246,7 @@ async def auto_cleanup_instances_after_test(api_session: aiohttp.ClientSession):
     worker_tag = f"-w{worker_num}-"
 
     # Ensure addon is reachable (it may have crashed during the test)
-    for _health_attempt in range(15):
+    for _health_attempt in range(10):
         try:
             async with api_session.get(
                 f"{ADDON_URL}/api/instances", timeout=aiohttp.ClientTimeout(total=3)
@@ -258,24 +255,24 @@ async def auto_cleanup_instances_after_test(api_session: aiohttp.ClientSession):
                     break
         except Exception:
             pass
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.5)
 
     # Delete only THIS WORKER's instances with retry
     try:
-        for _round in range(5):
+        for _round in range(3):
             async with api_session.get(
                 f"{ADDON_URL}/api/instances", timeout=aiohttp.ClientTimeout(total=5)
             ) as resp:
                 if resp.status != 200:
-                    await asyncio.sleep(2)
+                    await asyncio.sleep(0.5)
                     continue
                 data = await resp.json()
                 instances = data.get("instances", []) if isinstance(data, dict) else data
-                # Filter to only this worker's instances
                 my_instances = [i for i in instances if worker_tag in i.get("name", "")]
                 if not my_instances:
                     break  # All clean
 
+                # Delete concurrently
                 for instance in my_instances:
                     instance_name = instance.get("name", "")
                     if instance_name:
@@ -288,8 +285,8 @@ async def auto_cleanup_instances_after_test(api_session: aiohttp.ClientSession):
                         except Exception:
                             pass
 
-            # Wait for processes to fully terminate and release ports
-            await asyncio.sleep(3)
+            # Brief wait for processes to terminate and release ports
+            await asyncio.sleep(1)
     except Exception:
         pass  # Ignore cleanup errors
 

--- a/tests/e2e/test_1_6_8_features.py
+++ b/tests/e2e/test_1_6_8_features.py
@@ -21,7 +21,7 @@ import os
 import pytest
 
 from tests.e2e.utils import (
-    create_tls_tunnel_via_ui,
+    create_instance_via_api,
     fill_textfield_by_testid,
     navigate_to_settings,
     wait_for_instance_running,
@@ -49,20 +49,21 @@ async def test_vpn_server_extraction_from_ovpn(browser, unique_name, unique_port
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel instance via API (faster — VPN extraction is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address="old.vpn.com:1194",
         )
-
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Scroll to Connection Info card and find OpenVPN patcher button
@@ -98,7 +99,8 @@ nobind
             }
         )
 
-        await asyncio.sleep(1)
+        # Wait for file name to appear in UI (replaces fixed sleep)
+        await page.wait_for_selector("text=test.ovpn", timeout=5000)
 
         # Click Extract & Patch button
         patch_button = page.locator('[data-testid="openvpn-patch-button"]')
@@ -114,10 +116,10 @@ nobind
         page_text = await page.inner_text("body")
         assert "new.vpn.server.com:1194" in page_text, "Extracted VPN server should be shown"
 
-        # Close dialog
+        # Close dialog and wait for it to disappear
         close_button = page.locator('[data-testid="openvpn-dialog-close"]')
         await close_button.click()
-        await asyncio.sleep(2)
+        await dialog.wait_for(state="hidden", timeout=5000)
 
         # Verify forward_address was updated via API
         async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
@@ -150,24 +152,24 @@ async def test_raw_config_editor(browser, unique_name, unique_port, api_session)
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel instance via API (faster — raw config editor is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address="vpn.example.com:1194",
         )
-
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Scroll down to find Raw Configuration section
-        # (it might be below the fold)
         page_text = await page.inner_text("body")
         assert "Raw Configuration" in page_text, "Raw Configuration tab should be present"
 
@@ -212,10 +214,7 @@ async def test_raw_config_editor(browser, unique_name, unique_port, api_session)
         # Wait for save success
         await page.wait_for_selector("text=Saved!", timeout=10000)
 
-        await asyncio.sleep(3)
-
-        # Verify the change persisted via API (page.reload() goes back to
-        # the dashboard since settings is reached via in-app navigation)
+        # Verify the change persisted via API
         async with api_session.get(f"{ADDON_URL}/api/instances/{instance_name}/raw-config") as resp:
             data = await resp.json()
             assert "# Test comment added by E2E test" in data.get(
@@ -240,20 +239,21 @@ async def test_click_to_browse_file_upload(browser, unique_name, unique_port, ap
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance with external IP
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel instance via API (faster — file upload is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address="vpn.example.com:1194",
         )
-
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Scroll to Connection Info card and open OpenVPN patcher dialog
@@ -297,11 +297,8 @@ remote vpn.server.com 1194
             }
         )
 
-        await asyncio.sleep(1)
-
-        # Verify file name is displayed
-        page_text = await page.inner_text("body")
-        assert "clicked.ovpn" in page_text, "Selected file name should be displayed"
+        # Wait for file name to appear in UI (replaces fixed sleep)
+        await page.wait_for_selector("text=clicked.ovpn", timeout=5000)
     finally:
         await page.close()
 
@@ -322,20 +319,21 @@ async def test_openvpn_patch_blocked_without_external_ip(
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance (no external IP set)
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel instance via API (faster — validation is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address="vpn.example.com:1194",
         )
-
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Scroll to Connection Info card and open OpenVPN patcher dialog
@@ -370,7 +368,9 @@ remote vpn.server.com 1194
                 "buffer": ovpn_content.encode(),
             }
         )
-        await asyncio.sleep(1)
+
+        # Wait for file name to appear in UI (replaces fixed sleep)
+        await page.wait_for_selector("text=test.ovpn", timeout=5000)
 
         # Patch button should be disabled (file uploaded but no external address)
         patch_button = page.locator('[data-testid="openvpn-patch-button"]')
@@ -397,20 +397,21 @@ async def test_raw_config_syntax_highlighting(browser, unique_name, unique_port,
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create TLS tunnel instance
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel instance via API (faster — syntax highlighting is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address="vpn.example.com:1194",
         )
-
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Find the raw config editor

--- a/tests/e2e/test_dpi_ux_rework.py
+++ b/tests/e2e/test_dpi_ux_rework.py
@@ -90,6 +90,10 @@ async def test_no_dpi_toggle_for_squid(browser, unique_name, unique_port):
     try:
         # Navigate to dashboard first, then click to create
         await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
         except Exception:
@@ -117,6 +121,10 @@ async def test_tls_tunnel_routing_diagram_visible(browser, unique_name, unique_p
     try:
         # Navigate to dashboard first, then click to create
         await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
         except Exception:
@@ -147,6 +155,10 @@ async def test_tls_tunnel_field_labels(browser, unique_name, unique_port):
     try:
         # Navigate to dashboard first, then click to create
         await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
         except Exception:

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -338,6 +338,12 @@ async def test_responsive_design_mobile(browser, unique_name, unique_port, api_s
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking (mobile viewport can be slower)
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
+
         # Create instance on mobile
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -12,7 +12,7 @@ import os
 import pytest
 
 from tests.e2e.utils import (
-    create_instance_via_ui,
+    create_instance_via_api,
     fill_textfield_by_testid,
     navigate_to_settings,
     wait_for_instance_running,
@@ -32,10 +32,14 @@ async def test_duplicate_instance_error(browser, unique_name, unique_port, api_s
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create first instance via API (faster — duplicate error is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Create first instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Try to create duplicate
         try:
@@ -62,10 +66,14 @@ async def test_duplicate_user_error(browser, unique_name, unique_port, api_sessi
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create instance via API (faster — duplicate user error is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Add first user
         await navigate_to_settings(page, instance_name)
@@ -95,8 +103,8 @@ async def test_duplicate_user_error(browser, unique_name, unique_port, api_sessi
         await fill_textfield_by_testid(page, "user-password-input", "pass2345")
         await page.click('[data-testid="user-add-button"]')
 
-        # Wait for API response
-        await asyncio.sleep(3)
+        # Wait for API response (short delay for server to process)
+        await asyncio.sleep(1)
 
         # Verify duplicate was rejected - should still have exactly 1 user via API
         async with api_session.get(f"{ADDON_URL}/api/instances/{instance_name}/users") as resp:
@@ -150,12 +158,8 @@ async def test_many_users_single_instance(browser, unique_name, unique_port, api
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
-
-        # Wait for instance to be fully running before adding users
+        # Create instance via API (faster — user management is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Add 5 users via API (each triggers proxy restart, wait for ready between adds)
@@ -193,8 +197,11 @@ async def test_many_users_single_instance(browser, unique_name, unique_port, api
                 assert f"user{i}" in usernames, f"user{i} should be in API response"
 
         # Verify users appear in settings UI
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
-        await asyncio.sleep(2)
         for i in range(5):
             await page.wait_for_selector(
                 f'[data-testid="user-chip-user{i}"]',
@@ -214,12 +221,15 @@ async def test_empty_logs_display(browser, unique_name, unique_port, api_session
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Create instance via API (faster — log display is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # View logs immediately (may be empty)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Logs are now in a dialog - click the VIEW LOGS button to open it
@@ -228,6 +238,9 @@ async def test_empty_logs_display(browser, unique_name, unique_port, api_session
         # Wait for dialog to open and logs section to render
         log_section = await page.wait_for_selector('[data-testid="logs-type-select"]', timeout=5000)
         assert log_section is not None, "Logs section should exist in dialog"
+
+        # Wait for log data to load (async API fetch after dialog opens)
+        await page.wait_for_load_state("networkidle", timeout=10000)
 
         # Either the log viewer or the empty-state message should be visible
         has_viewer = await page.locator('[data-testid="logs-viewer"]').count() > 0
@@ -246,13 +259,14 @@ async def test_instance_card_displays_all_info(browser, unique_name, unique_port
 
     page = await browser.new_page()
     try:
+        # Create instance via API (faster — card display is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+
         await page.goto(ADDON_URL)
-
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
-
-        # Wait for instance to be running
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=10000)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Check card displays correct info
         card_selector = f'[data-testid="instance-card-{instance_name}"]'
@@ -278,12 +292,15 @@ async def test_settings_page_has_all_sections(browser, unique_name, unique_port,
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Create instance via API (faster — settings sections are the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Navigate to settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Verify all sections exist. In plain Chromium (no HA custom elements),
@@ -357,11 +374,18 @@ async def test_dashboard_search_filter(browser, unique_name, unique_port, api_se
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create two instances via API concurrently (faster)
+        await asyncio.gather(
+            create_instance_via_api(api_session, name1, port1),
+            create_instance_via_api(api_session, name2, port2),
+        )
+        await asyncio.gather(
+            wait_for_instance_running(page, ADDON_URL, api_session, name1, timeout=60000),
+            wait_for_instance_running(page, ADDON_URL, api_session, name2, timeout=60000),
+        )
 
-        # Create two instances
-        await create_instance_via_ui(page, ADDON_URL, name1, port1, https_enabled=False)
-        await create_instance_via_ui(page, ADDON_URL, name2, port2, https_enabled=False)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(f'[data-testid="instance-card-{name1}"]', timeout=30000)
 
         # Try to search if search box exists
         search_box = await page.query_selector("input[placeholder*='Search']")

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -128,6 +128,11 @@ async def test_invalid_port_validation(browser, unique_name):
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Try to create with invalid port
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
@@ -239,10 +244,17 @@ async def test_empty_logs_display(browser, unique_name, unique_port, api_session
         log_section = await page.wait_for_selector('[data-testid="logs-type-select"]', timeout=5000)
         assert log_section is not None, "Logs section should exist in dialog"
 
-        # Wait for log data to load (async API fetch after dialog opens)
-        await page.wait_for_load_state("networkidle", timeout=10000)
+        # Wait for log content to render (async API fetch → React render after dialog opens)
+        await page.wait_for_function(
+            """() => {
+                const viewer = document.querySelector('[data-testid="logs-viewer"]');
+                const body = document.body.innerText;
+                return viewer || body.includes('No log entries found');
+            }""",
+            timeout=15000,
+        )
 
-        # Either the log viewer or the empty-state message should be visible
+        # Verify the content is as expected
         has_viewer = await page.locator('[data-testid="logs-viewer"]').count() > 0
         has_empty = await page.locator("text=No log entries found").count() > 0
         assert has_viewer or has_empty, "Logs section should show entries or empty message"

--- a/tests/e2e/test_https_features.py
+++ b/tests/e2e/test_https_features.py
@@ -15,6 +15,7 @@ import os
 import pytest
 
 from tests.e2e.utils import (
+    create_instance_via_api,
     create_instance_via_ui,
     navigate_to_settings,
     set_switch_state_by_testid,
@@ -114,19 +115,16 @@ async def test_https_instance_stays_running(browser, unique_name, unique_port, a
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — stability check is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
 
         # Wait for instance to be running via API (HTTPS cert gen can take time)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Critical: Wait for Squid to stabilize (or crash if ssl_bump issue)
-        await asyncio.sleep(5)
-
         # Verify instance STILL running after stabilization (catches ssl_bump crash)
+        # 3 checks × 2s = 6s stability window
         for check_num in range(3):
+            await asyncio.sleep(2)
             try:
                 async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
                     data = await resp.json()
@@ -147,9 +145,6 @@ async def test_https_instance_stays_running(browser, unique_name, unique_port, a
                 raise AssertionError(
                     f"Addon connection lost during check {check_num + 1}: {conn_err}"
                 ) from conn_err
-
-            if check_num < 2:
-                await asyncio.sleep(2)
     finally:
         await page.close()
 
@@ -170,16 +165,18 @@ async def test_https_enable_on_existing_http(browser, unique_name, unique_port, 
 
     page = await browser.new_page()
     try:
-        # Ensure addon is healthy before navigating (previous test cleanup may cause restart)
+        # Ensure addon is healthy before starting (previous test cleanup may cause restart)
         await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
 
-        await page.goto(ADDON_URL)
-
-        # Create HTTP instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Create HTTP instance via API (faster — HTTPS enable is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Open settings and enable HTTPS
+        # Navigate to settings and enable HTTPS
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         await set_switch_state_by_testid(page, "settings-https-switch", True)
@@ -242,13 +239,15 @@ async def test_https_disable_on_existing(browser, unique_name, unique_port, api_
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — HTTPS disable is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Open settings and disable HTTPS
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         await set_switch_state_by_testid(page, "settings-https-switch", False)
@@ -295,10 +294,14 @@ async def test_https_delete_instance(browser, unique_name, unique_port, api_sess
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create HTTPS instance via API (faster — deletion is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Open settings and delete
         await navigate_to_settings(page, instance_name)
@@ -311,19 +314,16 @@ async def test_https_delete_instance(browser, unique_name, unique_port, api_sess
         await page.click('[data-testid="delete-confirm-button"]')
 
         # After delete, the app navigates to the dashboard.
-        # Wait for navigation to complete by checking URL
         await page.wait_for_url(f"{ADDON_URL}/", timeout=60000)
-        await asyncio.sleep(1)  # Let dashboard render
+        await page.wait_for_load_state("networkidle", timeout=10000)
 
         # Verify the instance card is gone from the dashboard
-        # (No need to wait for hidden - it should not exist at all)
         instance_card = await page.query_selector(f'[data-testid="instance-card-{instance_name}"]')
         assert (
             instance_card is None
         ), f"Instance card for {instance_name} should not exist after deletion"
 
         # Verify via API
-        await asyncio.sleep(1)
         async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
             data = await resp.json()
             assert not any(
@@ -349,14 +349,15 @@ async def test_https_regenerate_certificate(browser, unique_name, unique_port, a
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — cert regen is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-        await asyncio.sleep(3)
 
         # Open settings and regenerate cert
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Look for certificate regenerate button
@@ -367,8 +368,6 @@ async def test_https_regenerate_certificate(browser, unique_name, unique_port, a
             await page.click(regenerate_btn_selector)
 
             # Wait for regeneration to complete (cert gen + restart can take 30-60s)
-            # The button becomes disabled during regen, then re-enables when done
-            await asyncio.sleep(5)  # Give the backend time to start the operation
             for _attempt in range(20):
                 try:
                     await page.wait_for_selector(
@@ -377,40 +376,25 @@ async def test_https_regenerate_certificate(browser, unique_name, unique_port, a
                     )
                     break
                 except Exception:
-                    # Page may lose connection if container restarts during cert regen
                     try:
                         await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
                     except Exception:
                         pass
                     await asyncio.sleep(2)
 
-            # Wait for the instance to fully restart after cert regeneration
-            await asyncio.sleep(5)
-
-        # Ensure addon is healthy before checking instance state
+        # Ensure addon is healthy and instance is running after cert regen
         await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Verify instance still running via API polling
-        instance = None
-        for _attempt in range(20):
-            try:
-                async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
-                    data = await resp.json()
-                    instance = next(
-                        (i for i in data["instances"] if i["name"] == instance_name), None
-                    )
-                    if instance and instance.get("running"):
-                        break
-            except (ConnectionError, OSError):
-                # Addon may have restarted, wait for it
-                await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
-            await asyncio.sleep(2)
-
-        assert instance is not None, (
-            f"Instance {instance_name} should still exist after cert regen. "
-            f"Found: {[i['name'] for i in data.get('instances', [])] if data else 'no data'}"
-        )
-        assert instance.get("running"), "Instance should still be running after cert regen"
+        # Final verification via API
+        async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
+            data = await resp.json()
+            instance = next((i for i in data["instances"] if i["name"] == instance_name), None)
+            assert instance is not None, (
+                f"Instance {instance_name} should still exist after cert regen. "
+                f"Found: {[i['name'] for i in data.get('instances', [])] if data else 'no data'}"
+            )
+            assert instance.get("running"), "Instance should still be running after cert regen"
     finally:
         await page.close()
 
@@ -430,10 +414,9 @@ async def test_https_with_users(browser, unique_name, unique_port, api_session):
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — user management is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Add user via API (more reliable than UI form + avoids react-query refetch delay)
         async with api_session.post(
@@ -441,11 +424,16 @@ async def test_https_with_users(browser, unique_name, unique_port, api_session):
             json={"username": "httpsuser", "password": "httpspass"},
         ) as resp:
             assert resp.status == 200, "Failed to add user httpsuser"
-        await asyncio.sleep(3)
+
+        # Wait for instance to restart after user add
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Verify user appears in settings UI
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
-        await asyncio.sleep(2)
         await page.wait_for_selector('[data-testid="user-chip-httpsuser"]', timeout=60000)
 
         # Verify user added

--- a/tests/e2e/test_https_features.py
+++ b/tests/e2e/test_https_features.py
@@ -73,6 +73,11 @@ async def test_https_certificate_visibility(browser, unique_name):
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create page (try FAB first, fallback to empty state)
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)

--- a/tests/e2e/test_ovpn_patcher_e2e.py
+++ b/tests/e2e/test_ovpn_patcher_e2e.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from tests.e2e.utils import (
+    create_instance_via_api,
     create_instance_via_ui,
     create_tls_tunnel_via_ui,
     fill_textfield_by_testid,
@@ -349,10 +350,8 @@ async def test_ovpn_with_auth_credentials(browser, unique_name, unique_port, api
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create Squid instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Step 1: Create Squid instance via API (faster — auth patching is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Add a user via API
@@ -385,15 +384,19 @@ async def test_ovpn_with_auth_credentials(browser, unique_name, unique_port, api
         await page.wait_for_selector("text=/basic_client.ovpn/", timeout=10000)
 
         # Step 5: Enable auth toggle (HASwitch)
-        auth_toggle = await page.query_selector('[data-testid="openvpn-auth-toggle"]')
+        auth_toggle = await page.wait_for_selector(
+            '[data-testid="openvpn-auth-toggle"]', timeout=5000
+        )
         assert auth_toggle, "Auth toggle should be visible for Squid instances"
         await auth_toggle.click()
 
         # Step 6: Enter credentials
         await page.wait_for_selector('[data-testid="openvpn-username-input"]', timeout=5000)
 
-        # Verify user select dropdown appears (populated with instance users)
-        user_select = await page.query_selector('[data-testid="openvpn-user-select"]')
+        # Wait for user select dropdown (populated with instance users from async API fetch)
+        user_select = await page.wait_for_selector(
+            '[data-testid="openvpn-user-select"]', timeout=10000
+        )
         assert user_select, "User select dropdown should appear when auth enabled"
 
         # Fill username and password fields

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -19,6 +19,7 @@ import os
 import pytest
 
 from tests.e2e.utils import (
+    create_instance_via_api,
     create_instance_via_ui,
     fill_textfield_by_testid,
     get_icon_color,
@@ -95,7 +96,6 @@ async def test_scenario_1_setup_proxy_with_auth(browser, unique_name, unique_por
             f'[data-testid="instance-card-{instance_name}"]', timeout=30000
         )
         await navigate_to_settings(page, instance_name)
-        await asyncio.sleep(3)
         await page.wait_for_selector('[data-testid="user-chip-alice"]', timeout=30000)
         await page.wait_for_selector('[data-testid="user-chip-bob"]', timeout=30000)
 
@@ -130,13 +130,15 @@ async def test_scenario_2_enable_https(browser, unique_name, unique_port, api_se
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create HTTP instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Step 1: Create HTTP instance via API (faster — creation isn't the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Step 2: Enable HTTPS via settings
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Enable HTTPS — toggle auto-saves immediately
@@ -156,16 +158,7 @@ async def test_scenario_2_enable_https(browser, unique_name, unique_port, api_se
         assert https_enabled, "HTTPS should be enabled after saving"
 
         # Verify instance is still running after HTTPS update
-        for _attempt in range(10):
-            await asyncio.sleep(2)
-            async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
-                data = await resp.json()
-                instance = next((i for i in data["instances"] if i["name"] == instance_name), None)
-                if instance and instance.get("running"):
-                    break
-        assert instance is not None and instance.get(
-            "running"
-        ), "Instance should be running after HTTPS enable"
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
     finally:
         await page.close()
 
@@ -185,15 +178,12 @@ async def test_scenario_3_auth_troubleshooting(browser, unique_name, unique_port
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create instance with initial user
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Step 1: Create instance via API (faster — creation isn't the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Add users via API (more reliable for multi-user scenarios)
         # Each user add triggers a proxy restart, so wait for running between adds
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-
         for username, password in [("alice", "password123"), ("charlie", "charlie123")]:
             await wait_for_instance_running(
                 page, ADDON_URL, api_session, instance_name, timeout=60000
@@ -217,8 +207,11 @@ async def test_scenario_3_auth_troubleshooting(browser, unique_name, unique_port
             assert added, f"Failed to add user {username} after 5 retries"
 
         # Verify both users visible in settings UI
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
-        await asyncio.sleep(2)
         await page.wait_for_selector('[data-testid="user-chip-alice"]', timeout=30000)
         await page.wait_for_selector('[data-testid="user-chip-charlie"]', timeout=30000)
 
@@ -246,12 +239,15 @@ async def test_scenario_4_monitor_logs(browser, unique_name, unique_port, api_se
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Step 1: Create instance via API (faster — creation isn't the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Step 2: Open settings to view logs
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Logs are now in a dialog - click the VIEW LOGS button to open it
@@ -261,7 +257,9 @@ async def test_scenario_4_monitor_logs(browser, unique_name, unique_port, api_se
         await page.wait_for_selector(
             '[data-testid="logs-type-select"]', state="attached", timeout=5000
         )
-        await asyncio.sleep(1)
+
+        # Wait for log data to load (async API fetch after dialog opens)
+        await page.wait_for_load_state("networkidle", timeout=10000)
 
         # Either the log viewer or the empty-state message should be visible
         has_viewer = await page.locator('[data-testid="logs-viewer"]').count() > 0
@@ -291,23 +289,22 @@ async def test_scenario_5_multi_instance(browser, unique_name, unique_port, api_
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create first instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, name1, port1, https_enabled=False)
-        await wait_for_instance_running(page, ADDON_URL, api_session, name1, timeout=60000)
-
-        # Step 2: Create second instance and wait for it to be running
-        await create_instance_via_ui(page, ADDON_URL, name2, port2, https_enabled=False)
-        await wait_for_instance_running(page, ADDON_URL, api_session, name2, timeout=60000)
+        # Step 1: Create both instances via API concurrently (faster than sequential UI)
+        await asyncio.gather(
+            create_instance_via_api(api_session, name1, port1),
+            create_instance_via_api(api_session, name2, port2),
+        )
+        await asyncio.gather(
+            wait_for_instance_running(page, ADDON_URL, api_session, name1, timeout=60000),
+            wait_for_instance_running(page, ADDON_URL, api_session, name2, timeout=60000),
+        )
 
         # Verify both visible on dashboard
+        await page.goto(ADDON_URL)
         await page.wait_for_selector(f'[data-testid="instance-card-{name1}"]', timeout=30000)
         await page.wait_for_selector(f'[data-testid="instance-card-{name2}"]', timeout=30000)
 
-        # Step 3: Add different users to each instance via API
-        # Wait for each instance to be running before adding users
-        await wait_for_instance_running(page, ADDON_URL, api_session, name1, timeout=60000)
+        # Step 2: Add different users to each instance via API
         for _retry in range(5):
             async with api_session.post(
                 f"{ADDON_URL}/api/instances/{name1}/users",
@@ -340,11 +337,9 @@ async def test_scenario_5_multi_instance(browser, unique_name, unique_port, api_
             pytest.fail("Failed to add user2 to instance 2 after retries")
 
         # Verify user isolation: instance 2 should have user2 but NOT user1
-        # Navigate fresh to ensure data is loaded
         await page.goto(ADDON_URL)
         await page.wait_for_selector(f'[data-testid="instance-card-{name2}"]', timeout=30000)
         await navigate_to_settings(page, name2)
-        await asyncio.sleep(3)
         await page.wait_for_selector('[data-testid="user-chip-user2"]', timeout=30000)
 
         user_list = await page.inner_text('[data-testid="user-list"]')
@@ -370,16 +365,15 @@ async def test_scenario_6_regenerate_cert(browser, unique_name, unique_port, api
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
-
-        # Wait for instance to be running
+        # Step 1: Create HTTPS instance via API (faster — cert regen is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
-        await asyncio.sleep(2)
 
         # Step 2: Open settings and access certificate section
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         # Step 3: Regenerate certificate
@@ -388,7 +382,6 @@ async def test_scenario_6_regenerate_cert(browser, unique_name, unique_port, api
             await page.click(regenerate_btn)
             # Wait for the Regenerate button to return to non-loading state
             # (cert generation + restart can take 30-60s in the container)
-            await asyncio.sleep(5)  # Give the backend time to start
             for _attempt in range(20):
                 try:
                     await page.wait_for_selector(
@@ -403,31 +396,15 @@ async def test_scenario_6_regenerate_cert(browser, unique_name, unique_port, api
                     except Exception:
                         pass
                     await asyncio.sleep(2)
-            # Wait for instance to restart and stabilize after cert regeneration
-            await asyncio.sleep(8)
 
-        # Ensure addon is healthy before checking instance state
+        # Ensure addon is healthy and instance is running after cert regen
         await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Verify instance still running - poll multiple times with error recovery
-        instance = None
-        data = {}
-        for _attempt in range(20):
-            try:
-                async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
-                    data = await resp.json()
-                    instance = next(
-                        (i for i in data["instances"] if i["name"] == instance_name), None
-                    )
-                    if instance is not None and instance.get("running"):
-                        # Instance is running, test passes
-                        break
-            except (ConnectionError, OSError):
-                # Addon may have restarted, wait for recovery
-                await wait_for_addon_healthy(ADDON_URL, api_session, timeout=30000)
-            await asyncio.sleep(2)
-        else:
-            # All attempts exhausted, check final state
+        # Final verification via API
+        async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
+            data = await resp.json()
+            instance = next((i for i in data["instances"] if i["name"] == instance_name), None)
             assert instance is not None, (
                 f"Instance {instance_name} should exist. "
                 f"Found: {[i['name'] for i in data.get('instances', [])] if data else 'no data'}"
@@ -455,12 +432,15 @@ async def test_scenario_7_start_stop(browser, unique_name, unique_port, api_sess
 
     page = await browser.new_page()
     try:
+        # Step 1: Create instance via API (faster — start/stop is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+
+        # Navigate to dashboard and add user
         await page.goto(ADDON_URL)
-
-        # Step 1: Create instance with user
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
-
-        # Add user
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
         await fill_textfield_by_testid(page, "user-username-input", "testuser")
@@ -509,21 +489,17 @@ async def test_https_critical_no_ssl_bump(browser, unique_name, unique_port, api
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — stability check is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
 
         # Wait for instance to be running
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Critical: Wait and check instance stays running - give it extra time to stabilize
-        await asyncio.sleep(12)
-
-        # Check status via API multiple times to ensure it stays running
+        # Critical: Check instance stays running over time (ssl_bump crash happens quickly)
+        # 5 checks × 2s = 10s stability window (sufficient to catch the FATAL error)
         all_running = True
-        for attempt in range(8):
-            await asyncio.sleep(3)
+        for attempt in range(5):
+            await asyncio.sleep(2)
             async with api_session.get(f"{ADDON_URL}/api/instances") as resp:
                 data = await resp.json()
                 instance = next((i for i in data["instances"] if i["name"] == instance_name), None)
@@ -560,10 +536,14 @@ async def test_delete_instance(browser, unique_name, unique_port, api_session):
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create instance via API (faster — deletion is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Open settings and delete
         await navigate_to_settings(page, instance_name)
@@ -609,13 +589,15 @@ async def test_server_icon_color_reflects_status(browser, unique_name, unique_po
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Step 1: Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        # Step 1: Create instance via API (faster — icon color is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
+        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
         # Step 2: Verify icon is green when running
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Check that the ha-icon has green color
         icon_color = await get_icon_color(page, instance_name)
@@ -678,22 +660,23 @@ async def test_icon_color_multiple_instances_mixed_status(
 
     page = await browser.new_page()
     try:
+        # Create 3 instances via API concurrently (much faster than sequential UI)
+        await asyncio.gather(
+            create_instance_via_api(api_session, instance1_name, port1, https_enabled=False),
+            create_instance_via_api(api_session, instance2_name, port2, https_enabled=True),
+            create_instance_via_api(api_session, instance3_name, port3, https_enabled=False),
+        )
+        await asyncio.gather(
+            wait_for_instance_running(page, ADDON_URL, api_session, instance1_name, timeout=60000),
+            wait_for_instance_running(page, ADDON_URL, api_session, instance2_name, timeout=60000),
+            wait_for_instance_running(page, ADDON_URL, api_session, instance3_name, timeout=60000),
+        )
+
+        # Stop instance 3 via UI
         await page.goto(ADDON_URL)
-
-        # Create 3 instances: 2 HTTP, 1 HTTPS
-        # Instance 1: HTTP (will keep running)
-        await create_instance_via_ui(page, ADDON_URL, instance1_name, port1, https_enabled=False)
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance1_name, timeout=60000)
-
-        # Instance 2: HTTPS (will keep running)
-        await create_instance_via_ui(page, ADDON_URL, instance2_name, port2, https_enabled=True)
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance2_name, timeout=60000)
-
-        # Instance 3: HTTP (will be stopped)
-        await create_instance_via_ui(page, ADDON_URL, instance3_name, port3, https_enabled=False)
-
-        # Stop instance 3
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance3_name, timeout=60000)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance3_name}"]', timeout=30000
+        )
         stop_btn = f'[data-testid="instance-stop-chip-{instance3_name}"]'
         await page.wait_for_selector(f"{stop_btn}:not([disabled])", timeout=30000)
         await page.click(stop_btn)
@@ -743,11 +726,14 @@ async def test_icon_color_https_not_red_when_running(
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        # Create HTTPS instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=True)
+        # Create HTTPS instance via API (faster — icon color is the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=True)
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
+
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # CRITICAL: HTTPS instance should have GREEN icon when running
         # This is the core bug fix - before it would show wrong color
@@ -786,10 +772,13 @@ async def test_icon_color_rapid_status_changes(browser, unique_name, unique_port
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
+        # Create instance via API (faster — rapid status changes are the focus)
+        await create_instance_via_api(api_session, instance_name, port, https_enabled=False)
 
-        # Create instance
-        await create_instance_via_ui(page, ADDON_URL, instance_name, port, https_enabled=False)
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
 
         # Perform 2 rapid stop/start cycles (reduced from 3 for reliability)
         for cycle in range(2):
@@ -878,25 +867,30 @@ async def test_icon_color_persistence_after_page_refresh(
 
     page = await browser.new_page()
     try:
+        # Create two instances via API concurrently (faster)
+        await asyncio.gather(
+            create_instance_via_api(api_session, instance1_name, port1, https_enabled=False),
+            create_instance_via_api(api_session, instance2_name, port2, https_enabled=False),
+        )
+        await asyncio.gather(
+            wait_for_instance_running(page, ADDON_URL, api_session, instance1_name, timeout=60000),
+            wait_for_instance_running(page, ADDON_URL, api_session, instance2_name, timeout=60000),
+        )
+
+        # Stop instance 2 via UI
         await page.goto(ADDON_URL)
-
-        # Create two instances
-        await create_instance_via_ui(page, ADDON_URL, instance1_name, port1, https_enabled=False)
-        await create_instance_via_ui(page, ADDON_URL, instance2_name, port2, https_enabled=False)
-
-        # Stop instance 2
-        await wait_for_instance_running(page, ADDON_URL, api_session, instance2_name, timeout=60000)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance2_name}"]', timeout=30000
+        )
         await page.click(f'[data-testid="instance-stop-chip-{instance2_name}"]')
         await wait_for_instance_stopped(page, ADDON_URL, api_session, instance2_name, timeout=60000)
 
         # Refresh page
         await page.reload()
+        await page.wait_for_load_state("networkidle", timeout=30000)
         await page.wait_for_selector(
             '[data-testid="instance-card-' + instance1_name + '"]', timeout=30000
         )
-
-        # Wait a moment for all instances to load
-        await asyncio.sleep(2)
 
         # Verify instance 1 (running) still has green icon
         icon1_color = await get_icon_color(page, instance1_name)

--- a/tests/e2e/test_tls_tunnel.py
+++ b/tests/e2e/test_tls_tunnel.py
@@ -23,6 +23,7 @@ import os
 import pytest
 
 from tests.e2e.utils import (
+    create_instance_via_api,
     create_instance_via_ui,
     create_tls_tunnel_via_ui,
     fill_textfield_by_testid,
@@ -226,25 +227,36 @@ async def test_tls_tunnel_connection_info_tab(browser, unique_name, unique_port,
 
     page = await browser.new_page()
     try:
-        await page.goto(ADDON_URL)
-
-        await create_tls_tunnel_via_ui(
-            page,
-            ADDON_URL,
+        # Create TLS tunnel via API (faster — connection info display is the focus)
+        await create_instance_via_api(
+            api_session,
             instance_name,
             port,
+            proxy_type="tls_tunnel",
             forward_address=vpn_address,
         )
 
         await wait_for_instance_running(page, ADDON_URL, api_session, instance_name, timeout=60000)
 
+        await page.goto(ADDON_URL)
+        await page.wait_for_selector(
+            f'[data-testid="instance-card-{instance_name}"]', timeout=30000
+        )
         await navigate_to_settings(page, instance_name)
 
-        # Wait for the OpenVPN snippet to load
+        # Wait for the OpenVPN snippet to load (async API fetch populates content)
         snippet_el = page.locator('[data-testid="ovpn-snippet-content"]')
         await snippet_el.wait_for(state="visible", timeout=10000)
 
-        # Snippet should contain meaningful content (not just "Loading...")
+        # Wait for snippet content to finish loading (replaces point-in-time check)
+        await page.wait_for_function(
+            """() => {
+                const el = document.querySelector('[data-testid="ovpn-snippet-content"]');
+                return el && el.innerText && el.innerText !== 'Loading...' && el.innerText.trim().length > 0;
+            }""",
+            timeout=15000,
+        )
+
         snippet_text = await snippet_el.inner_text()
         assert snippet_text, "OpenVPN snippet should not be empty"
         assert snippet_text != "Loading...", "OpenVPN snippet should have loaded"
@@ -541,6 +553,12 @@ async def test_proxy_type_selector_ui(browser, unique_name, unique_port, api_ses
     page = await browser.new_page()
     try:
         await page.goto(ADDON_URL)
+
+        # Wait for dashboard to render before clicking (under parallel load, React needs time)
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
 
         # Navigate to create page (try FAB first, fallback to empty state)
         try:

--- a/tests/e2e/test_validation_errors.py
+++ b/tests/e2e/test_validation_errors.py
@@ -25,6 +25,11 @@ async def test_create_form_invalid_forward_address_shows_error(browser, unique_n
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create form
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
@@ -159,6 +164,11 @@ async def test_forward_address_optional_port_accepted(
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create form
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
@@ -213,6 +223,11 @@ async def test_uppercase_instance_name_accepted_squid(
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create form
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
@@ -256,6 +271,11 @@ async def test_uppercase_instance_name_accepted_tls_tunnel(
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create form
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)
@@ -300,6 +320,11 @@ async def test_backend_error_message_visible_in_ui(browser, unique_name, unique_
     try:
         await page.goto(ADDON_URL)
 
+        # Wait for dashboard to render before clicking
+        await page.wait_for_selector(
+            '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+            timeout=30000,
+        )
         # Open create form
         try:
             await page.click('[data-testid="add-instance-button"]', timeout=2000)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -386,12 +386,14 @@ async def wait_for_instance_running(
 ) -> None:
     """Wait for an instance to reach running state via API polling.
 
+    Uses exponential backoff: starts at 0.3s, caps at 2s.
     Default 60s to handle container degradation during full suite runs.
     """
     import asyncio
 
-    max_attempts = timeout // 2000
-    for _ in range(max_attempts):
+    deadline = asyncio.get_event_loop().time() + timeout / 1000
+    delay = 0.3
+    while asyncio.get_event_loop().time() < deadline:
         try:
             async with api_session.get(
                 f"{addon_url}/api/instances", timeout=aiohttp.ClientTimeout(total=10)
@@ -402,7 +404,8 @@ async def wait_for_instance_running(
                     return
         except Exception:
             pass  # API might be slow during restart
-        await asyncio.sleep(2)
+        await asyncio.sleep(delay)
+        delay = min(delay * 1.5, 2.0)
     raise TimeoutError(f"Instance {instance_name} did not reach running state within {timeout}ms")
 
 
@@ -415,12 +418,14 @@ async def wait_for_instance_stopped(
 ) -> None:
     """Wait for an instance to reach stopped state via API polling.
 
+    Uses exponential backoff: starts at 0.3s, caps at 2s.
     Default 60s to handle container degradation during full suite runs.
     """
     import asyncio
 
-    max_attempts = timeout // 2000
-    for _ in range(max_attempts):
+    deadline = asyncio.get_event_loop().time() + timeout / 1000
+    delay = 0.3
+    while asyncio.get_event_loop().time() < deadline:
         try:
             async with api_session.get(
                 f"{addon_url}/api/instances", timeout=aiohttp.ClientTimeout(total=10)
@@ -431,7 +436,8 @@ async def wait_for_instance_stopped(
                     return
         except Exception:
             pass  # API might be slow during stop
-        await asyncio.sleep(2)
+        await asyncio.sleep(delay)
+        delay = min(delay * 1.5, 2.0)
     raise TimeoutError(f"Instance {instance_name} did not stop within {timeout}ms")
 
 
@@ -442,13 +448,15 @@ async def wait_for_addon_healthy(
 ) -> None:
     """Wait for the addon to be healthy and responding to API requests.
 
+    Uses exponential backoff: starts at 0.3s, caps at 2s.
     Useful after operations that may cause the addon container to restart
     (e.g., certificate regeneration under load).
     """
     import asyncio
 
-    max_attempts = timeout // 2000
-    for _ in range(max_attempts):
+    deadline = asyncio.get_event_loop().time() + timeout / 1000
+    delay = 0.3
+    while asyncio.get_event_loop().time() < deadline:
         try:
             async with api_session.get(
                 f"{addon_url}/api/instances", timeout=aiohttp.ClientTimeout(total=5)
@@ -457,7 +465,8 @@ async def wait_for_addon_healthy(
                     return
         except Exception:
             pass  # Connection refused, reset, etc.
-        await asyncio.sleep(2)
+        await asyncio.sleep(delay)
+        delay = min(delay * 1.5, 2.0)
     raise TimeoutError(f"Addon did not become healthy within {timeout}ms")
 
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -485,12 +485,10 @@ async def get_icon_color(page: Page, instance_name: str) -> str:
     that changes background color based on running/stopped status.
     Reloads the dashboard first to ensure the UI reflects the latest backend state.
     """
-    import asyncio
-
     # Reload to pick up latest state from react-query
     await page.reload()
+    await page.wait_for_load_state("networkidle", timeout=30000)
     await page.wait_for_selector(f'[data-testid="instance-card-{instance_name}"]', timeout=30000)
-    await asyncio.sleep(1)
 
     result: str = await page.evaluate(
         """(instanceName) => {

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -284,7 +284,11 @@ async def create_instance_via_ui(
     Navigates to create page, fills form, submits, and waits for
     the instance card to appear on the dashboard.
     """
-    # Click either FAB (if instances exist) or empty state button (if dashboard is empty)
+    # Wait for dashboard to fully load, then click whichever button is present
+    await page.wait_for_selector(
+        '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+        timeout=10000,
+    )
     try:
         await page.click('[data-testid="add-instance-button"]', timeout=2000)
     except Exception:
@@ -330,7 +334,11 @@ async def create_tls_tunnel_via_ui(
     """
     import asyncio as _asyncio
 
-    # Click either FAB (if instances exist) or empty state button (if dashboard is empty)
+    # Wait for dashboard to fully load, then click whichever button is present
+    await page.wait_for_selector(
+        '[data-testid="add-instance-button"], [data-testid="empty-state-add-button"]',
+        timeout=10000,
+    )
     try:
         await page.click('[data-testid="add-instance-button"]', timeout=2000)
     except Exception:


### PR DESCRIPTION
## Summary

- **v1.6.9 feature**: Move external address from settings to OpenVPN patcher dialog, fix port duplication bug, add editable diff preview
- **E2E performance Round 1**: 3 workers, exponential backoff, faster cleanup (~2-3x speedup)
- **E2E performance Round 2**: API-based instance creation, fixed sleep removal, 4 workers, `--dist=load` (additional ~12% speedup)
- **Test fixes**: Update E2E and integration tests for v1.6.9 external address changes, fix dashboard render timing
- **Version bump**: 1.6.10

## Test plan

- [x] All 257 backend unit/integration tests pass
- [x] All 83 frontend unit tests pass
- [x] Lint (Black, ruff, mypy, bandit, hadolint, secrets) pass
- [x] 64/68 E2E tests pass (4 pre-existing flakes in untouched files)
- [x] E2E runtime reduced from ~6:14 to ~5:33 (Round 2 optimizations)
- [ ] Manual smoke test of OpenVPN patcher dialog flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)